### PR TITLE
Window resizing

### DIFF
--- a/video.c
+++ b/video.c
@@ -106,6 +106,7 @@ video_init(uint8_t *in_chargen)
 	SDL_Init(SDL_INIT_VIDEO);
 	SDL_CreateWindowAndRenderer(SCREEN_WIDTH, SCREEN_HEIGHT, 0, &window, &renderer);
 	SDL_SetWindowResizable(window, true);
+	SDL_RenderSetLogicalSize(renderer, SCREEN_WIDTH, SCREEN_HEIGHT);
 
 	sdlTexture = SDL_CreateTexture(renderer,
 				       SDL_PIXELFORMAT_RGB888,

--- a/video.c
+++ b/video.c
@@ -105,6 +105,7 @@ video_init(uint8_t *in_chargen)
 
 	SDL_Init(SDL_INIT_VIDEO);
 	SDL_CreateWindowAndRenderer(SCREEN_WIDTH, SCREEN_HEIGHT, 0, &window, &renderer);
+	SDL_SetWindowResizable(window, true);
 
 	sdlTexture = SDL_CreateTexture(renderer,
 				       SDL_PIXELFORMAT_RGB888,


### PR DESCRIPTION
I started playing around getting familiar with SDL and this emulator.

The changes in this PR are making the SDL window resizable and keeping the aspect ratio intact.


If changes in this area are something you agree with , let me know and I can continue working in this direction. I thought it would also be nice to put in a size multiplier for the aspect ratio as a command line parameter to start out the emulator with for example 2x the window size and having maybe menu items for doubling screen size. 
Also, at least on the Mac I have problems from going from full screen mode back to 'normal' mode, so I was going to look at it as well.

