### PR TITLE
Bugfix to video.c

### DIFF
--- a/video.c
+++ b/video.c
@@ -424,9 +424,9 @@ get_pixel(uint8_t layer, uint16_t x, uint16_t y)
 		bool bit = (s >> (7 - xx)) & 1;
 		col_index = bit ? fg_color : bg_color;
 	} else if (bits_per_pixel == 2) {
-		col_index = (s >> (6 - (xx << 1))) & 3;
+		col_index = (s >> (6 - ((xx & 3) << 1))) & 3;
 	} else if (bits_per_pixel == 4) {
-		col_index = (s >> (4 - (xx << 2))) & 0xf;
+		col_index = (s >> (4 - ((xx & 1) << 2))) & 0xf;
 	} else if (bits_per_pixel == 8) {
 		col_index = s;
 	}


### PR DESCRIPTION
Looks like 2bpp and 4bpp drawing is attempting to shift too many bits when xx (x position within a tile) is would be outside the bounds of the first byte in a tile's row.

Consider the following BASIC to enable Layer 1 as a 4bpp tile layer with 16x16 sprites, with tile index 0 in the top-left corner:
10 VPOKE 4,$10,%01100001
20 VPOKE 4,$11,%00110001
30 VPOKE 4,$12,$00
40 VPOKE 4,$13,$10
50 VPOKE 4,$14,$00
60 VPOKE 4,$15,$14
70 VPOKE 0,$4000,0
80 VPOKE 0,$4001,0

This next line will place a white pixel in the upper-left corner of the tile, as expected:
VPOKE 0,$5000,%00010000

This will color the neighboring pixel as well, as expected:
VPOKE 0,$5000,%00010001

This, however, should color the next pixel in the row, but appears to do nothing prior to this fix:
VPOKE 0,$5001,%00010000

2bpp tiles were similarly affected. By only grabbing the bottom bits of xx to constrain it to within the byte that we're operating on, get_pixel() appears to return the correct palette index for 2bpp and 4bpp tiles at all memory addresses.