### PR TITLE
Allow emulation to switch emulator features on or off.

### DIFF
--- a/glue.h
+++ b/glue.h
@@ -22,6 +22,8 @@ extern uint8_t ROM[];
 extern bool debuger_enabled;
 extern bool log_video;
 extern bool log_keyboard;
+extern bool echo_mode;
+extern bool save_on_exit;
 
 extern void machine_reset();
 extern void machine_paste();

--- a/main.c
+++ b/main.c
@@ -32,6 +32,8 @@ bool pasting_bas = false;
 bool log_video = false;
 bool log_speed = false;
 bool log_keyboard = false;
+bool echo_mode = false;
+bool save_on_exit = true;
 
 #ifdef TRACE
 #include "rom_labels.h"
@@ -138,7 +140,6 @@ main(int argc, char **argv)
 	char *bas_path = NULL;
 	char *sdcard_path = NULL;
 
-	bool echo_mode = false;
 	bool run_after_load = false;
 
 #ifdef __APPLE__
@@ -434,7 +435,9 @@ main(int argc, char **argv)
 #endif
 
 		if (pc == 0xffff) {
-			memory_save();
+			if (save_on_exit) {
+				memory_save();
+			}
 			break;
 		}
 

--- a/memory.h
+++ b/memory.h
@@ -14,4 +14,7 @@ void memory_save();
 void memory_set_ram_bank(uint8_t bank);
 void memory_set_rom_bank(uint8_t bank);
 
+uint8_t emu_read(uint8_t reg);
+void emu_write(uint8_t reg, uint8_t value);
+
 #endif


### PR DESCRIPTION
This adds a new device at $9FB0 to $9FB4 that is wired
to some of the emulator features. Allows you to turn features
on and off from within the emulation.
$9FB0	Debugger
$9FB1	Video access logging
$9FB2	Keyboard logging
$9FB3	Echo mode
$9FB4	Save on exit:
	Should the emulator save a memory image
	when $FFFF is called?

Usage:
POKE $9FB3,1:PRINT"ECHO MODE IS ON":POKE $9FB3,0

POKE $9FB4,0:SYS $FFFF:REM Exit without saving a memory image.