### PR TITLE
Fix to issue #33: LOAD into RAM bank

### DIFF
--- a/loadsave.c
+++ b/loadsave.c
@@ -9,6 +9,7 @@
 #include <dirent.h>
 #include <unistd.h>
 #include "glue.h"
+#include "memory.h"
 
 #define MIN(a,b) (((a)<(b))?(a):(b))
 #define MAX(a,b) (((a)>(b))?(a):(b))
@@ -145,7 +146,19 @@ LOAD()
 			start = start_hi << 8 | start_lo;
 		}
 
-		size_t bytes_read = fread(RAM + start, 1, 0x9f00 - start, f);
+		size_t bytes_read = 0;
+		if(start < 0x9f00) {
+			// Fixed RAM
+			bytes_read = fread(RAM + start, 1, 0x9f00 - start, f);
+		} else if(start < 0xa000) {
+			// IO addresses
+		} else if(start < 0xc000) { 
+			// banked RAM
+			bytes_read = fread(RAM + ((uint16_t)memory_get_ram_bank() << 13) + start, 1, 0xc000 - start, f);
+		} else {
+			// ROM
+		}
+
 		fclose(f);
 
 		uint16_t end = start + bytes_read;

--- a/memory.c
+++ b/memory.c
@@ -147,6 +147,11 @@ memory_set_ram_bank(uint8_t bank)
 	ram_bank = bank & (NUM_RAM_BANKS - 1);
 }
 
+uint8_t memory_get_ram_bank()
+{
+	return ram_bank;
+}
+
 void
 memory_set_rom_bank(uint8_t bank)
 {

--- a/memory.h
+++ b/memory.h
@@ -14,6 +14,8 @@ void memory_save();
 void memory_set_ram_bank(uint8_t bank);
 void memory_set_rom_bank(uint8_t bank);
 
+uint8_t memory_get_ram_bank();
+
 uint8_t emu_read(uint8_t reg);
 void emu_write(uint8_t reg, uint8_t value);
 


### PR DESCRIPTION
Adding logic to LOAD() to place the file into the proper RAM bank if loaded into a RAM bank address. I'm not sure if final hardware/kernel will intelligently cap read length to the banked memory limit, similar to how the emulator enforces the fixed memory limit, or if large files would potentially overflow (failing to write to ROM, of course) and/or wrap-around back to RAM address 0x0000 and write forwards from there.

I've assumed an intelligent cap will be enforced like in the fixed RAM case. If that's not the case, I'm happy to instead implement whatever the behavior should be.