### PR TITLE
Compile for Linux and macOS on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+dist: bionic
+sudo: required
+language: c
+
+matrix:
+  include:
+    - os: linux
+      addons:
+        apt:
+          packages:
+            - libsdl2-dev
+      compiler: gcc
+      script: make
+    - os: osx
+      osx_image: xcode11
+      addons:
+        homebrew:
+          packages:
+            - sdl2 
+      script: make 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This is an emulator for the Commander X16 computer system. It only depends on SDL2 and should compile on all modern operating systems.
 
-## Binaries & Compiling
+## Binaries & Compiling 
+
+<a href="https://travis-ci.org/commanderx16/x16-emulator"><img alt="Travis (.org)" src="https://img.shields.io/travis/commanderx16/x16-emulator.svg?label=CI&logo=travis&logoColor=white&style=for-the-badge"></a>
 
 Binary releases for macOS, Windows and x86_64 Linux are available on the [releases page](https://github.com/commanderx16/x16-emulator/releases).
 


### PR DESCRIPTION
This patch introduces continuous integration for Linux and macOS using Travis CI. It should help verifying that pull requests actually compile and for multiple platforms. Even better, if test cases are added then they can be run automatically to verify nothing breaks.

A future improvement to this would be to add AppVeyor that supports Windows builds.

**Note** that the owner of the repository will have to go to Travis-CI.org and enable CI for this repository. I've done it for my fork and both Linux and macOS builds pass.