### PR TITLE
Allow specifying image scaling quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ You can start `x16emu`/`x16emu.exe` either by double-clicking it, or from the co
 * `-run` executes the application specified through `-prg` or `-bas` using `RUN` or `SYS`, depending on the load address.
 * `-scale` scales video output to an integer multiple of 640x480
 * `-echo` causes all KERNAL/BASIC output to be printed to the host's terminal. Enable this and use the BASIC command "LIST" to convert a BASIC program to ASCII (detokenize).
+* `-scale` scales video output to an integer multiple of 640x480
+* `-quality` change image scaling algorithm quality
+	* `nearest`: nearest pixel sampling
+	* `linear`: linear filtering
+	* `best`: (default) anisotropic filtering
 * `-log` enables one or more types of logging (e.g. `-log KS`):
 	* `K`: keyboard (key-up and key-down events)
 	* `S`: speed (CPU load, frame misses)

--- a/main.c
+++ b/main.c
@@ -76,6 +76,7 @@ bool record_gif = false;
 char *gif_path = NULL;
 uint8_t keymap = 0; // KERNAL's default
 int window_scale = 1;
+char *scale_quality = "best";
 
 #ifdef TRACE
 bool trace_mode = false;
@@ -223,7 +224,8 @@ usage()
 	printf("\tEnable debugger. Optionally, set a breakpoint\n");
 	printf("-scale {1|2|3|4}\n");
 	printf("\tScale output to an integer multiple of 640x480\n");
-	printf("\tEnable debugger.\n");
+	printf("-quality {nearest|linear|best}\n");
+	printf("\tScaling algorithm quality\n");
 #ifdef TRACE
 	printf("-trace [<address>]\n");
 	printf("\tPrint instruction trace. Optionally, a trigger address\n");
@@ -474,6 +476,21 @@ main(int argc, char **argv)
 			}
 			argc--;
 			argv++;
+		} else if (!strcmp(argv[0], "-quality")) {
+			argc--;
+			argv++;
+			if(!argc || argv[0][0] == '-') {
+				usage();
+			}
+			if (!strcmp(argv[0], "nearest") ||
+			    !strcmp(argv[0], "linear") ||
+			    !strcmp(argv[0], "best")) {
+				scale_quality = argv[0];
+			} else {
+				usage();
+			}
+			argc--;
+			argv++;
 		} else {
 			usage();
 		}
@@ -545,9 +562,9 @@ main(int argc, char **argv)
 #endif
 	
 #ifdef VERA_V0_8
-	video_init(window_scale);
+	video_init(window_scale, scale_quality);
 #else
-	video_init(chargen, window_scale);
+	video_init(chargen, window_scale, scale_quality);
 #endif
 	spi_init();
 	vera_spi_init();

--- a/video.c
+++ b/video.c
@@ -160,9 +160,9 @@ video_reset()
 
 bool
 #ifdef VERA_V0_8
-video_init(int window_scale)
+video_init(int window_scale, char *quality)
 #else
-video_init(uint8_t *in_chargen, int window_scale)
+video_init(uint8_t *in_chargen, int window_scale, char *quality)
 #endif
 {
 #ifndef VERA_V0_8
@@ -173,6 +173,7 @@ video_init(uint8_t *in_chargen, int window_scale)
 	video_reset();
 
 	SDL_Init(SDL_INIT_VIDEO);
+	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, quality);
 	SDL_CreateWindowAndRenderer(SCREEN_WIDTH * window_scale, SCREEN_HEIGHT * window_scale, 0, &window, &renderer);
 #ifndef __MORPHOS__
 	SDL_SetWindowResizable(window, true);

--- a/video.h
+++ b/video.h
@@ -11,9 +11,9 @@
 #include "glue.h"
 
 #ifdef VERA_V0_8
-bool video_init(int window_scale);
+bool video_init(int window_scale, char *quality);
 #else
-bool video_init(uint8_t *chargen, int window_scale);
+bool video_init(uint8_t *chargen, int window_scale, char *quality);
 #endif
 void video_reset(void);
 bool video_step(float mhz);


### PR DESCRIPTION
This patch enables the use of alternative SDL scaling algorithms to improve image quality when using a non integer scaling ratio (i.e.: when manually resizing the emulator window).