### PR TITLE
Fix M_PI macro redefined error

### DIFF
--- a/ym2151.c
+++ b/ym2151.c
@@ -146,7 +146,7 @@ int32_t        dt1_freq[8*32];      /* 8 DT1 levels, 32 KC values */
 uint32_t       noise_tab[32];       /* 17bit Noise Generator periods */
 
 
-#define M_PI             3.14159265358979323846
+#define PI               3.14159265358979323846
 
 #define FREQ_SH          16  /* 16.16 fixed point (frequency calculations) */
 #define EG_SH            16  /* 16.16 fixed point (envelope generator timing) */
@@ -505,7 +505,7 @@ void YM_init_tables()
     for (i=0; i<SIN_LEN; i++)
     {
         /* non-standard sinus */
-        m = sin( ((i*2)+1) * M_PI / SIN_LEN ); /* verified on the real chip */
+        m = sin( ((i*2)+1) * PI / SIN_LEN ); /* verified on the real chip */
 
         /* we never reach zero here due to ((i*2)+1) */
 


### PR DESCRIPTION
When compiling on macOS (with Apple Clang) using `WITH_YM2151=1`, I was getting the following error:

```
ym2151.c:149:9: error: 'M_PI' macro redefined [-Werror,-Wmacro-redefined]
#define M_PI             3.14159265358979323846
        ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/math.h:692:9: note: 
      previous definition is here
#define M_PI        3.14159265358979323846264338327950288   /* pi             */
        ^
1 error generated.
make: *** [ym2151.o] Error 1
```

This appears to be because `math.h` is also defining `M_PI`, and the use of `-Werror` is causing the warning to become an error. I changed the macro name to `PI` to avoid the conflict.

Alternative solutions include only defining `M_PI` if it isn't already defined (with `#ifndef M_PI`) or explicitly re-defining the macro (with `#undef M_PI`). Changing the macro name seemed like a simpler solution to me, though.