### PR TITLE
[WITH_YM2151] Add -sound option, and related SDL and audio code upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ You can start `x16emu`/`x16emu.exe` either by double-clicking it, or from the co
 	* `R`: RAM (40 KiB)
 	* `B`: Banked RAM (2 MiB)
 	* `V`: Video RAM and registers (128 KiB VRAM, 32 B composer registers, 512 B pallete, 16 B layer0 registers, 16 B layer1 registers, 16 B sprite registers, 2 KiB sprite attributes)
+* When compiled with `WITH_YM2151`, `-sound` can be used to specify the output sound device.
 * When compiled with `#define TRACE`, `-trace` will enable an instruction trace on stdout.
 
 Run `x16emu -h` to see all command line options.

--- a/main.c
+++ b/main.c
@@ -345,7 +345,7 @@ void initAudio()
 	}
 
 	// init YM2151 emulation. 4 MHz clock
-	YM_Create(1.0f, 4000000);
+	YM_Create(4000000);
 	YM_init(have.freq, 60);
 
 	// start playback

--- a/video.c
+++ b/video.c
@@ -171,7 +171,6 @@ video_init(uint8_t *in_chargen, int window_scale, char *quality)
 
 	video_reset();
 
-	SDL_Init(SDL_INIT_VIDEO);
 	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, quality);
 	SDL_CreateWindowAndRenderer(SCREEN_WIDTH * window_scale, SCREEN_HEIGHT * window_scale, 0, &window, &renderer);
 #ifndef __MORPHOS__
@@ -897,7 +896,6 @@ video_end()
 
 	SDL_DestroyRenderer(renderer);
 	SDL_DestroyWindow(window);
-	SDL_Quit();
 }
 
 

--- a/ym2151.c
+++ b/ym2151.c
@@ -33,9 +33,6 @@ uint8_t YM_channels;
 
 int YM_irq;
 
-// Volume of sound chip
-float YM_volume;
-
 void YM_clear_buffer();
 void YM_write_buffer(const uint8_t, uint32_t, int16_t);
 int16_t YM_read_buffer(const uint8_t, uint32_t);
@@ -453,12 +450,9 @@ static const uint8_t lfo_noise_waveform[256] = {
 static FILE *sample[9];
 #endif
 
-void YM_Create(float volume, uint32_t clock)
+void YM_Create(uint32_t clock)
 {
-    YM_volume     = 1.0;
     YM_initalized = 0;
-
-    YM_volume = volume;  
     YM_clock = clock;
 }
 
@@ -2127,8 +2121,8 @@ void YM_stream_update(uint16_t* stream, int samples)
         if (outr > MAXOUT) outr = MAXOUT;
             else if (outr < MINOUT) outr = MINOUT;
         
-        stream[2 * i] = (int16_t) (outl * YM_volume);
-        stream[2 * i + 1] = (int16_t) (outr * YM_volume);
+        stream[2 * i] = (int16_t) outl;
+        stream[2 * i + 1] = (int16_t) outr;
 
 #ifdef USE_MAME_TIMERS
         /* ASG 980324 - handled by real timers now */
@@ -2154,13 +2148,4 @@ void YM_stream_update(uint16_t* stream, int samples)
 #endif
         YM_advance();
     }
-}
-
-// Set soundchip volume (0 = Off, 10 = Loudest)
-void YM_set_volume(uint8_t v)
-{
-    if (v > 10) 
-        return;
-    
-    YM_volume = (float) (v / 10.0);
 }

--- a/ym2151.h
+++ b/ym2151.h
@@ -68,11 +68,10 @@ typedef struct
 } YM2151Operator;
 
 
-void YM_Create(float volume, uint32_t clock);
+void YM_Create(uint32_t clock);
 
 void YM_init(int rate, int fps);
 void YM_stream_update(uint16_t* stream, int samples);
-void YM_set_volume(uint8_t);
 
 void YM_write_reg(int r, int v);
 uint32_t YM_read_status();


### PR DESCRIPTION
This adds a new command-line option `-sound <output device>`, which allows you to specify the output device used to play the emulated audio. This is a minor feature that became trivial to implement with some code restructuring I ended up doing.

I replaced `SDL_OpenAudio()` with `SDL_OpenAudioDevice()`. The former really only exists to make updating SDL 1.2 programs easier, and the functions with the `Device` suffix are generally intended to be used for new code. One nice advantage to this function is that you can specify exactly which parameters in the provided `SDL_AudioSpec` are required by your program, and allows SDL to perform conversions behind-the-scenes for you if the requested format isn't directly supported. This allowed me to remove the check to make sure the audio device we get is using signed 16-bit samples. I delayed the initialization of the YM2151 emulator until after getting the audio device so I could initialize it with the sample rate we actually got. I also added an explicit call to close the opened audio device to have proper cleanup.

I moved the calls to `SDL_Init()` and `SDL_Quit()` from `video.c` to `main.c`. Since SDL is starting to be used by components other than video (audio, and possibly joystick later), initializing SDL in `main()` makes sense. I also moved the call to `video_end()` from `emulator_loop()` to `main()` to match the location of `SDL_Quit()`. Lastly, along with adding `SDL_INIT_AUDIO` to `SDL_Init()` (required to use the `Device` versions of the audio functions), I added `SDL_INIT_EVENTS` since we do use that subsystem (It's implicitly initialized when initializing video, so it's not strictly required).