### PR TITLE
[WebAssembly] Better browser support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ endif
 
 ifdef EMSCRIPTEN
 	# Todo #--js-library webassembly/helper.js
-	LDFLAGS+=--shell-file webassembly/x16emu-template.html  --preload-file rom.bin --preload-file chargen.bin -s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1 -s USE_PTHREADS=1 
+	LDFLAGS+=--shell-file webassembly/x16emu-template.html  --preload-file rom.bin -s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1 
 	# To the Javascript runtime exported functions
 	LDFLAGS+=-s EXPORTED_FUNCTIONS='["_j2c_reset", "_j2c_paste", _main]' -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]'
 	

--- a/sdcard.c
+++ b/sdcard.c
@@ -6,6 +6,7 @@
 #include "sdcard.h"
 
 static int cmd_receive_counter;
+FILE *sdcard_file = NULL;
 
 void
 sdcard_select()

--- a/sdcard.h
+++ b/sdcard.h
@@ -1,10 +1,13 @@
 // Commander X16 Emulator
 // Copyright (c) 2019 Michael Steil
 // All rights reserved. License: 2-clause BSD
-
+#ifndef _SD_CARD_H_
+#define _SD_CARD_H_
 #include <inttypes.h>
 
-FILE *sdcard_file;
+extern FILE *sdcard_file;
 
 void sdcard_select();
 uint8_t sdcard_handle(uint8_t inbyte);
+
+#endif

--- a/spi.c
+++ b/spi.c
@@ -18,7 +18,6 @@
 // CB1 SPICLK (=PB0)
 // CB2 MISO
 
-FILE *sdcard_file = NULL;
 
 static bool initialized;
 

--- a/spi.h
+++ b/spi.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2019 Michael Steil
 // All rights reserved. License: 2-clause BSD
 
-#ifndef _SDCARD_H_
-#define _SDCARD_H_
+#ifndef _SPI_H_
+#define _SPI_H_
 
 void spi_init();
 void spi_step();

--- a/webassembly/WebAssembly.md
+++ b/webassembly/WebAssembly.md
@@ -12,7 +12,7 @@ Follow installation steps from [here](https://emscripten.org/docs/getting_starte
 
 This outputs the following artifacts in the build directory, which can be uploaded to any web server.
 
-	ex16mu.data x16emu.html x16emu.js x16mu.wasm x16emuworker.js
+	ex16mu.data x16emu.html x16emu.js x16mu.wasm x16emuworker.js webassembly/styles.css webassembly/heper.js
 
 ### Testing
 To run a test webserver:
@@ -22,8 +22,13 @@ To run a test webserver:
 And start [http://localhost:8080/x16emu.html](http://localhost:8080/x16emu.html)
 
 ### Supported Browsers
-Currently supported Browser is Google Chrome only.
+Working Browsers are Chrome, Safari, FireFox, Opera and Microsoft Edge (Beta)
 
-FireFox will work if SharedMemory is enabled from preferences (but comes with Security implications).
-
-Safari is not supported.
+### Known Issues
+* Speed of the webassembly emulation is lacking, compared to the native version
+* Copy Clipboard button only works on Chrome
+* Ctrl-V is not working
+* Resizing doesn't work all that well
+* No support to load PRGs
+* General keyboard input support on Mobile browsers
+   


### PR DESCRIPTION
Webkit, Safari, Chrome on Android and Opera supported now.
Removed threading as it is not supported currently on browsers other than Chrome Desktop.
Changed Main emulator loop to yield control back to the browser after a complete frame.
Setting emscripten main loop fps parameter to 0, as this is highly recommended in emscripten documentation.
Lastly, reworked imports for *sdcard_file, due to a compile error using the llvm webassembly backend.