### PR TITLE
removed not needed volume setting and adding float support for audio

### DIFF
--- a/ym2151.c
+++ b/ym2151.c
@@ -33,9 +33,6 @@ uint8_t YM_channels;
 
 int YM_irq;
 
-// Volume of sound chip
-float YM_volume;
-
 void YM_clear_buffer();
 void YM_write_buffer(const uint8_t, uint32_t, int16_t);
 int16_t YM_read_buffer(const uint8_t, uint32_t);
@@ -453,12 +450,10 @@ static const uint8_t lfo_noise_waveform[256] = {
 static FILE *sample[9];
 #endif
 
-void YM_Create(float volume, uint32_t clock)
+void YM_Create(uint32_t clock)
 {
-    YM_volume     = 1.0;
     YM_initalized = 0;
 
-    YM_volume = volume;  
     YM_clock = clock;
 }
 
@@ -2056,7 +2051,7 @@ void YM_advance()
 *   '**buffers' is table of pointers to the buffers: left and right
 *   'length' is the number of samples that should be generated
 */
-void YM_stream_update(uint16_t* stream, int samples)
+void YM_stream_update(uint8_t* stream, int samples, int audio_float)
 {
     uint32_t i;
     int32_t outl,outr;
@@ -2127,8 +2122,15 @@ void YM_stream_update(uint16_t* stream, int samples)
         if (outr > MAXOUT) outr = MAXOUT;
             else if (outr < MINOUT) outr = MINOUT;
         
-        stream[2 * i] = (int16_t) (outl * YM_volume);
-        stream[2 * i + 1] = (int16_t) (outr * YM_volume);
+        if (audio_float) {
+            float* streamf = (float*) stream;
+            streamf[2 * i] = ((float) outl) / 32769.0f;
+            streamf[2 * i + 1] = ((float) outr) / 32769.0f;
+        } else {
+            uint16_t* stream16 = (uint16_t*) stream;
+            stream16[2 * i] = (int16_t) outl;
+            stream16[2 * i + 1] = (int16_t) outr;
+        }
 
 #ifdef USE_MAME_TIMERS
         /* ASG 980324 - handled by real timers now */
@@ -2154,13 +2156,4 @@ void YM_stream_update(uint16_t* stream, int samples)
 #endif
         YM_advance();
     }
-}
-
-// Set soundchip volume (0 = Off, 10 = Loudest)
-void YM_set_volume(uint8_t v)
-{
-    if (v > 10) 
-        return;
-    
-    YM_volume = (float) (v / 10.0);
 }

--- a/ym2151.h
+++ b/ym2151.h
@@ -68,11 +68,10 @@ typedef struct
 } YM2151Operator;
 
 
-void YM_Create(float volume, uint32_t clock);
+void YM_Create(uint32_t clock);
 
 void YM_init(int rate, int fps);
-void YM_stream_update(uint16_t* stream, int samples);
-void YM_set_volume(uint8_t);
+void YM_stream_update(uint8_t* stream, int samples, int audio_float);
 
 void YM_write_reg(int r, int v);
 uint32_t YM_read_status();


### PR DESCRIPTION
@sebastianvog with this patch, it should work for the wasm target. At least the SDL init functions don't fail anymore, and I tested the float functionality for the normal target and it worked. But it didn't work in my browser (Chrome on Linux). But this example worked:
https://googlechromelabs.github.io/web-audio-samples/audio-worklet/design-pattern/wasm/
Maybe you have an idea.
You can compile it with audio support, if you set the environment variable `WITH_YM2151` to `1` before calling `make wasm`. You can test it with this program:
http://www.frank-buss.de/x16/audio.prg