### PR TITLE
Add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = tab
+insert_final_newline = true
+tab_width = 4
+trim_trailing_whitespace = true
+
+[*.yml]
+indent_style = space
+
+[*.py]
+indent_style = space


### PR DESCRIPTION
Hello!

I observed that a lot of comments in the pull requests are about whitespace issues as this project uses tabs instead of spaces.
If the editor supports it, an editorconfig file will automagically use the correct settings instead of the users default.
See https://editorconfig.org/ for more information.

Note that I have set indent style to space for yml and python files because the [CI services don't like tabs](https://ci.appveyor.com/project/madebr/x16-emulator/builds/27530204) and [python linters complain](https://ci.appveyor.com/project/madebr/x16-emulator/builds/27530261/job/on99s5b8gfpxjxim#L134) about tabs.