### PR TITLE
Flush stdout after echo-ing character

### DIFF
--- a/main.c
+++ b/main.c
@@ -842,6 +842,7 @@ emulator_loop(void *param)
 				c = 10;
 			}
 			printf("%c", c);
+			fflush(stdout);
 		}
 
 		if (pc == 0xffcf && is_kernal()) {


### PR DESCRIPTION
See #117

This pr will let
```
./x16emu -echo | cat
```
behave unbuffered by flushing the stdout buffer after an echo