### PR TITLE
Adds a new -echo option: -echoraw

### DIFF
--- a/main.c
+++ b/main.c
@@ -70,6 +70,7 @@ bool dump_ram = true;
 bool dump_bank = true;
 bool dump_vram = false;
 bool echo_mode = false;
+bool echo_raw = false;
 bool save_on_exit = true;
 bool record_gif = false;
 char *gif_path = NULL;
@@ -440,6 +441,10 @@ main(int argc, char **argv)
 			argc--;
 			argv++;
 			echo_mode = true;
+		} else if (!strcmp(argv[0], "-echoraw")) {
+			argc--;
+			argv++;
+			echo_raw = true;
 		} else if (!strcmp(argv[0], "-log")) {
 			argc--;
 			argv++;
@@ -805,13 +810,18 @@ emulator_loop(void *param)
 			break;
 		}
 
-		if (echo_mode && pc == 0xffd2 && is_kernal()) {
+		if (pc == 0xffd2 && is_kernal()) {
 			uint8_t c = a;
-			if (c == 13) {
-				c = 10;
+			if (echo_raw) {
+				printf("%c", c);
+				fflush(stdout);
+			} else if (echo_mode) {
+				if (c == 0x0d) {
+					c = 0x0a;
+				}
+				printf("%c", c);
+				fflush(stdout);
 			}
-			printf("%c", c);
-			fflush(stdout);
 		}
 
 		if (pc == 0xffcf && is_kernal()) {

--- a/main.c
+++ b/main.c
@@ -444,6 +444,7 @@ main(int argc, char **argv)
 		} else if (!strcmp(argv[0], "-echoraw")) {
 			argc--;
 			argv++;
+			echo_mode = true;
 			echo_raw = true;
 		} else if (!strcmp(argv[0], "-log")) {
 			argc--;
@@ -810,18 +811,15 @@ emulator_loop(void *param)
 			break;
 		}
 
-		if (pc == 0xffd2 && is_kernal()) {
+		if (echo_mode && pc == 0xffd2 && is_kernal()) {
 			uint8_t c = a;
-			if (echo_raw) {
-				printf("%c", c);
-				fflush(stdout);
-			} else if (echo_mode) {
+			if (!echo_raw) {
 				if (c == 0x0d) {
 					c = 0x0a;
 				}
-				printf("%c", c);
-				fflush(stdout);
 			}
+			printf("%c", c);
+			fflush(stdout);
 		}
 
 		if (pc == 0xffcf && is_kernal()) {


### PR DESCRIPTION
Option -echoraw is needed for some filter programs. It doesn't change CR to LF, or anything else.

Example of filter that needs this feature in order to make the output in the terminal look the same as on the screen: https://github.com/mobluse/x16-petscii2utf8

This feature would also be needed if one wants to directly output all types of binary files from the emulator.