### PR TITLE
Allow emulator to start/stop GIF recording.

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ All rights reserved. License: 2-clause BSD
 
 ## Release Notes
 
+### Next Release
+
+* `-gif <filename>` will start recording on `POKE $9FB5,3`. It will capture a single frame on `POKE $9FB5,1` and pause recording on `POKE $9FB5,0`. `PEEK($9FB5)` returns a 128 if recording is enabled but not active.
+
 ### Release 32
 
 * correct ROM banking

--- a/glue.h
+++ b/glue.h
@@ -41,7 +41,7 @@ extern bool log_video;
 extern bool log_keyboard;
 echo_mode_t echo_mode;
 extern bool save_on_exit;
-extern bool record_gif;
+extern uint8_t record_gif;
 extern char *gif_path;
 extern uint8_t keymap;
 

--- a/main.c
+++ b/main.c
@@ -75,7 +75,7 @@ bool dump_bank = true;
 bool dump_vram = false;
 echo_mode_t echo_mode;
 bool save_on_exit = true;
-bool record_gif = false;
+uint8_t record_gif = 0;
 char *gif_path = NULL;
 uint8_t keymap = 0; // KERNAL's default
 int window_scale = 1;
@@ -305,6 +305,8 @@ usage()
 	printf("\tMultiple characters are possible, e.g. -log KS\n");
 	printf("-gif <file.gif>\n");
 	printf("\tRecord a gif for the video output.\n");
+	printf("\tPOKE $9FB5,3 to start recording, POKE $9FB5,0 to pause.\n");
+	printf("\tPOKE $9FB5,1 to capture a single frame.\n");
 	printf("-scale {1|2|3|4}\n");
 	printf("\tScale output to an integer multiple of 640x480\n");
 	printf("-quality {nearest|linear|best}\n");
@@ -578,7 +580,7 @@ main(int argc, char **argv)
 		} else if (!strcmp(argv[0], "-gif")) {
 			argc--;
 			argv++;
-			record_gif = true;
+			record_gif = 128; // set up but don't start recording
 			if (!argc || argv[0][0] == '-') {
 				usage();
 			}

--- a/memory.c
+++ b/memory.c
@@ -179,7 +179,8 @@ memory_get_rom_bank()
 //        bit:  7     6  5  4  3  2  1           0
 // record_gif: [ctrl][0][0][0][0][0][continuous][active]
 void
-emu_recorder_set(uint8_t newstate) {
+emu_recorder_set(uint8_t newstate)
+{
 	// turning off while recording is enabled
 	if (newstate == 0 && record_gif > 0) {
 		record_gif = 128; // need to save
@@ -214,7 +215,7 @@ emu_write(uint8_t reg, uint8_t value)
 		case 2: log_keyboard = v; break;
 		case 3: echo_mode = v; break;
 		case 4: save_on_exit = v; break;
-		case 5: emu_recorder_set(v); break;
+		case 5: emu_recorder_set(value); break;
 		default: printf("WARN: Invalid register %x\n", DEVICE_EMULATOR + reg);
 	}
 }


### PR DESCRIPTION
`POKE $9FB5,1` to snap one frame to the .gif file.
`POKE $9FB5,3` to start recording.
`POKE $9FB5,0` to stop recording.

Breaking Change: You have to poke to start the recording, it won't start unless you do the poke.

Why: I do lots of recordings and sometimes I don't want to include the X16 splash screen. Sometimes I want just one frame, or I want to take one snap each time my drawing loop is done.
The attached recording shows starting the recording after modifying the display (still the splash screen, but at 80x30 resolution.)
![recording](https://user-images.githubusercontent.com/476626/66050268-2540e180-e4ea-11e9-8990-1bc4fa260957.gif)
