### PR TITLE
Allow control of .gif recording from within the emulator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Release Notes
 
 ### Next Release
 
-* `-gif <filename>` will start recording on `POKE $9FB5,3`. It will capture a single frame on `POKE $9FB5,1` and pause recording on `POKE $9FB5,0`. `PEEK($9FB5)` returns a 128 if recording is enabled but not active.
+* `-gif <filename>,wait` will start recording on `POKE $9FB5,2`. It will capture a single frame on `POKE $9FB5,1` and pause recording on `POKE $9FB5,0`. `PEEK($9FB5)` returns a 128 if recording is enabled but not active. Please exit the emulator before reading the saved .gif file.
 
 ### Release 32
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ Known Issues
 Release Notes
 -------------
 
+### Next Release
+
+* `-gif <filename>` will start recording on `POKE $9FB5,3`. It will capture a single frame on `POKE $9FB5,1` and pause recording on `POKE $9FB5,0`. `PEEK($9FB5)` returns a 128 if recording is enabled but not active.
+
 ### Release 32
 
 * correct ROM banking

--- a/glue.h
+++ b/glue.h
@@ -41,7 +41,7 @@ extern bool log_video;
 extern bool log_keyboard;
 echo_mode_t echo_mode;
 extern bool save_on_exit;
-extern bool record_gif;
+extern uint8_t record_gif;
 extern char *gif_path;
 extern uint8_t keymap;
 

--- a/glue.h
+++ b/glue.h
@@ -29,6 +29,18 @@ typedef enum {
 	ECHO_MODE_ISO,
 } echo_mode_t;
 
+// GIF recorder commands
+#define RECORD_GIF_PAUSE	0
+#define RECORD_GIF_SNAP		1
+#define RECORD_GIF_RESUME	2
+
+// GIF recorder states
+// [paused] [0] [0] [0] [0] [0] [continuous] [active]
+#define RECORD_GIF_PAUSED	128
+#define RECORD_GIF_ACTIVE	3
+#define RECORD_GIF_SINGLE	1
+#define RECORD_GIF_DISABLED	0
+
 extern uint8_t a, x, y, sp, status;
 extern uint16_t pc;
 extern uint8_t *RAM;

--- a/main.c
+++ b/main.c
@@ -75,7 +75,7 @@ bool dump_bank = true;
 bool dump_vram = false;
 echo_mode_t echo_mode;
 bool save_on_exit = true;
-uint8_t record_gif = 0;
+uint8_t record_gif = RECORD_GIF_DISABLED;
 char *gif_path = NULL;
 uint8_t keymap = 0; // KERNAL's default
 int window_scale = 1;
@@ -306,8 +306,9 @@ usage()
 	printf("-gif <file.gif>[,wait]\n");
 	printf("\tRecord a gif for the video output.\n");
 	printf("\tUse ,wait to start paused.\n");
-	printf("\tPOKE $9FB5,3 to start recording, POKE $9FB5,0 to pause.\n");
+	printf("\tPOKE $9FB5,2 to start recording.\n");
 	printf("\tPOKE $9FB5,1 to capture a single frame.\n");
+	printf("\tPOKE $9FB5,0 to pause.\n");
 	printf("-scale {1|2|3|4}\n");
 	printf("\tScale output to an integer multiple of 640x480\n");
 	printf("-quality {nearest|linear|best}\n");
@@ -581,7 +582,8 @@ main(int argc, char **argv)
 		} else if (!strcmp(argv[0], "-gif")) {
 			argc--;
 			argv++;
-			record_gif = 255; // set up for recording
+			// set up for recording
+			record_gif = RECORD_GIF_PAUSED; 
 			if (!argc || argv[0][0] == '-') {
 				usage();
 			}

--- a/main.c
+++ b/main.c
@@ -75,7 +75,7 @@ bool dump_bank = true;
 bool dump_vram = false;
 echo_mode_t echo_mode;
 bool save_on_exit = true;
-bool record_gif = false;
+uint8_t record_gif = 0;
 char *gif_path = NULL;
 uint8_t keymap = 0; // KERNAL's default
 int window_scale = 1;
@@ -305,6 +305,8 @@ usage()
 	printf("\tMultiple characters are possible, e.g. -log KS\n");
 	printf("-gif <file.gif>\n");
 	printf("\tRecord a gif for the video output.\n");
+	printf("\tPOKE $9FB5,3 to start recording, POKE $9FB5,0 to pause.\n");
+	printf("\tPOKE $9FB5,1 to capture a single frame.\n");
 	printf("-scale {1|2|3|4}\n");
 	printf("\tScale output to an integer multiple of 640x480\n");
 	printf("-quality {nearest|linear|best}\n");
@@ -578,7 +580,7 @@ main(int argc, char **argv)
 		} else if (!strcmp(argv[0], "-gif")) {
 			argc--;
 			argv++;
-			record_gif = true;
+			record_gif = 128; // set up but don't start recording
 			if (!argc || argv[0][0] == '-') {
 				usage();
 			}

--- a/main.c
+++ b/main.c
@@ -303,8 +303,9 @@ usage()
 	printf("-log {K|S|V}...\n");
 	printf("\tEnable logging of (K)eyboard, (S)peed, (V)ideo.\n");
 	printf("\tMultiple characters are possible, e.g. -log KS\n");
-	printf("-gif <file.gif>\n");
+	printf("-gif <file.gif>[,wait]\n");
 	printf("\tRecord a gif for the video output.\n");
+	printf("\tUse ,wait to start paused.\n");
 	printf("\tPOKE $9FB5,3 to start recording, POKE $9FB5,0 to pause.\n");
 	printf("\tPOKE $9FB5,1 to capture a single frame.\n");
 	printf("-scale {1|2|3|4}\n");
@@ -580,7 +581,7 @@ main(int argc, char **argv)
 		} else if (!strcmp(argv[0], "-gif")) {
 			argc--;
 			argv++;
-			record_gif = 128; // set up but don't start recording
+			record_gif = 255; // set up for recording
 			if (!argc || argv[0][0] == '-') {
 				usage();
 			}

--- a/main.c
+++ b/main.c
@@ -583,7 +583,7 @@ main(int argc, char **argv)
 			argc--;
 			argv++;
 			// set up for recording
-			record_gif = RECORD_GIF_PAUSED; 
+			record_gif = RECORD_GIF_PAUSED;
 			if (!argc || argv[0][0] == '-') {
 				usage();
 			}

--- a/memory.c
+++ b/memory.c
@@ -176,22 +176,22 @@ memory_get_rom_bank()
 }
 
 // Control the GIF recorder
-//        bit:  7     6  5  4  3  2  1           0
-// record_gif: [ctrl][0][0][0][0][0][continuous][active]
+//        bit:  7       6  5  4  3  2  1           0
+// record_gif: [paused][0][0][0][0][0][continuous][active]
 void
-emu_recorder_set(uint8_t newstate)
+emu_recorder_set(uint8_t command)
 {
 	// turning off while recording is enabled
-	if (newstate == 0 && record_gif > 0) {
-		record_gif = 128; // need to save
+	if (command == RECORD_GIF_PAUSE && record_gif != RECORD_GIF_DISABLED) {
+		record_gif = RECORD_GIF_PAUSED; // need to save
 	}
 	// turning on continuous recording
-	if (newstate == 3 && record_gif > 0) {
-		record_gif = 3;		// activate recording
+	if (command == RECORD_GIF_RESUME && record_gif != RECORD_GIF_DISABLED) {
+		record_gif = RECORD_GIF_ACTIVE;		// activate recording
 	}
 	// capture one frame
-	if (newstate == 1 && record_gif > 0) {
-		record_gif = 1;		// single-shot
+	if (command == RECORD_GIF_SNAP && record_gif != RECORD_GIF_DISABLED) {
+		record_gif = RECORD_GIF_SINGLE;		// single-shot
 	}
 }
 

--- a/memory.c
+++ b/memory.c
@@ -179,7 +179,8 @@ memory_get_rom_bank()
 //        bit:  7     6  5  4  3  2  1           0
 // record_gif: [ctrl][0][0][0][0][0][continuous][active]
 void
-emu_recorder_set(uint8_t newstate) {
+emu_recorder_set(uint8_t newstate)
+{
 	// turning off while recording is enabled
 	if (newstate == 0 && record_gif > 0) {
 		record_gif = 128; // need to save
@@ -214,7 +215,7 @@ emu_write(uint8_t reg, uint8_t value)
 		case 2: log_keyboard = v; break;
 		case 3: echo_mode = v; break;
 		case 4: save_on_exit = v; break;
-		case 5: emu_recorder_set(v); break;
+		case 5: emu_recorder_set(value); break;
 		default: printf("WARN: Invalid register %x\n", DEVICE_EMULATOR + reg);
 	}
 }

--- a/video.c
+++ b/video.c
@@ -158,7 +158,16 @@ video_init(int window_scale, char *quality)
 
 	SDL_SetWindowTitle(window, "Commander X16");
 
-	if (record_gif & 128) {
+	if (record_gif > 0) {
+		if (!strcmp(gif_path+strlen(gif_path)-5, ",wait")) {
+			// wait for POKE
+			record_gif = 128;
+			// move the string terminator to remove the ",wait"
+			gif_path[strlen(gif_path)-5] = 0;
+		} else {
+			// start now
+			record_gif = 3;
+		}
 		if (!GifBegin(&gif_writer, gif_path, SCREEN_WIDTH, SCREEN_HEIGHT, 1, 8, false)) {
 			record_gif = 0;
 		}

--- a/video.c
+++ b/video.c
@@ -158,18 +158,18 @@ video_init(int window_scale, char *quality)
 
 	SDL_SetWindowTitle(window, "Commander X16");
 
-	if (record_gif > 0) {
+	if (record_gif != RECORD_GIF_DISABLED) {
 		if (!strcmp(gif_path+strlen(gif_path)-5, ",wait")) {
 			// wait for POKE
-			record_gif = 128;
+			record_gif = RECORD_GIF_PAUSED;
 			// move the string terminator to remove the ",wait"
 			gif_path[strlen(gif_path)-5] = 0;
 		} else {
 			// start now
-			record_gif = 3;
+			record_gif = RECORD_GIF_ACTIVE;
 		}
 		if (!GifBegin(&gif_writer, gif_path, SCREEN_WIDTH, SCREEN_HEIGHT, 1, 8, false)) {
-			record_gif = 0;
+			record_gif = RECORD_GIF_DISABLED;
 		}
 	}
 
@@ -874,15 +874,15 @@ video_update()
 {
 	SDL_UpdateTexture(sdlTexture, NULL, framebuffer, SCREEN_WIDTH * 4);
 
-	if (record_gif & 1) {
+	if (record_gif & RECORD_GIF_SINGLE) {
 		if(!GifWriteFrame(&gif_writer, framebuffer, SCREEN_WIDTH, SCREEN_HEIGHT, 2, 8, false)) {
 			// if that failed, stop recording
 			GifEnd(&gif_writer);
-			record_gif = 0;
+			record_gif = RECORD_GIF_DISABLED;
 			printf("Unexpected end of recording.\n");
 		}
-		if (record_gif == 1) { // if single-shot stop recording
-			record_gif = 128;  // need to close in video_end()
+		if (record_gif == RECORD_GIF_SINGLE) { // if single-shot stop recording
+			record_gif = RECORD_GIF_PAUSED;  // need to close in video_end()
 		}
 	}
 
@@ -997,8 +997,9 @@ video_update()
 void
 video_end()
 {
-	if (record_gif > 0) {
+	if (record_gif != RECORD_GIF_DISABLED) {
 		GifEnd(&gif_writer);
+		record_gif = RECORD_GIF_DISABLED;
 	}
 
 	SDL_DestroyRenderer(renderer);


### PR DESCRIPTION
-gif capture.gif (works as always)
-gif capture.gif,wait (start with recording paused)

`POKE $9FB5,1` to record a single frame.
`POKE $9FB5,3` to start or resume recording.
`POKE $9FB5,0` to stop recording.

`PEEK($9FB5)` to check the recording status. Returns 128=paused, 3=recording, 1=snapshot pending, 0=recording inactive (-gif not specified on command line, or write to .gif failed), 255=feature not present (running on actual hardware??).

In this clip the recording doesn't start until the second time through the loop.
![spin](https://user-images.githubusercontent.com/476626/66148879-226bec80-e5cf-11e9-9447-683f2d070774.gif)
