### PR TITLE
Video optimization (Linux CPU 100% usage, Issue #51)

### DIFF
--- a/video.c
+++ b/video.c
@@ -641,16 +641,13 @@ render_line(uint16_t y)
 {
 	uint8_t out_mode = reg_composer[0] & 3;
 
-	float hscale = 128.0 / reg_composer[1];
-	float vscale = 128.0 / reg_composer[2];
-
 	uint8_t border_color = reg_composer[3];
 	uint16_t hstart = reg_composer[4] | (reg_composer[8] & 3) << 8;
 	uint16_t hstop = reg_composer[5] | ((reg_composer[8] >> 2) & 3) << 8;
 	uint16_t vstart = reg_composer[6] | ((reg_composer[8] >> 4) & 1) << 8;
 	uint16_t vstop = reg_composer[7] | ((reg_composer[8] >> 5) & 1) << 8;
 
-	int eff_y = 1.0 / vscale * (y - vstart);
+	int eff_y = (reg_composer[2] * (y - vstart)) / 128;
 	render_sprite_line(eff_y);
 	render_layer_line(0, eff_y);
 	render_layer_line(1, eff_y);
@@ -680,7 +677,7 @@ render_line(uint16_t y)
 
 			int eff_x[LAYER_PIXELS_PER_ITERATION];
 			for (int i = 0; i < LAYER_PIXELS_PER_ITERATION; ++i) {
-				eff_x[i] = 1.0 / hscale * (x + i - hstart);
+				eff_x[i] = (reg_composer[1] * (x + i - hstart)) / 128;
 			}
 
 			if (!sprite_line_empty) {


### PR DESCRIPTION
- render_line:
  - Recalculating the XRGB color from palette per line only when changed, not when writing to the framebuffer.
  - Split up the loop over pixels in a line into discrete stages:
      1) Calculate color indices.
      2) Add border.
      3) Look up XRGB color & write to framebuffer.
      4) Apply NTSC overscan.
   - Calculate 8 color indices per iteration (was only maybe a 50ms improvement for quite a bit more complexity... probably be much nicer if flatted by hand to SIMD intrinsics)

- render_layer_line:
  - Calculate VRAM range to read in, and read in the range rather than several individual bytes when the range lies within VRAM, otherwise fallback to individual byte reads.

Timing video_step over 300 frames (158025 calls):
Baseline:
    2477.246284 ms total, 0.015676 ms avg,
    **8.257487613 ms/frame**

Plus optimized render_line:
    1848.739386 ms total, 0.011699 ms avg,
    **6.16246462 ms/frame**

Plus optimized render_layer_line:
    1673.707724 ms total, 0.010591 ms avg,
    **5.579025747 ms/frame**

Additional testing with @indigodarkwolf's x16-racer, using "-log S" specifically:
```
Before (Settles at 88-90%):
Load: 100%
Rendering is behind -58 frames.
Load: 100%
Rendering is behind -58 frames.
Load: 100%
Rendering is behind -58 frames.
Load: 100%
Rendering is behind -58 frames.
Load: 100%
Rendering is behind -59 frames.
Load: 100%
Rendering is behind -59 frames.
Load: 100%
Rendering is behind -59 frames.
Load: 100%
Rendering is behind -59 frames.
Load: 100%
Rendering is behind -59 frames.
```
After:
```
Load: 100%
Load: 88%
Load: 94%
Load: 94%
Load: 82%
Load: 100%
Load: 88%
Load: 88%
Load: 88%
Load: 100%
Load: 82%
Load: 100%
Load: 88%
Load: 94%
Load: 82%
```

Test CPU is an Intel(R) Core(TM) i5-5250U CPU @ 1.60GHz.