### PR TITLE
skip IO area when loading PRG files

### DIFF
--- a/loadsave.h
+++ b/loadsave.h
@@ -7,5 +7,6 @@
 
 void LOAD();
 void SAVE();
+size_t readBanked(FILE* f, uint16_t start);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -965,7 +965,8 @@ emulator_loop(void *param)
 				} else {
 					start = start_hi << 8 | start_lo;
 				}
-				uint16_t end = start + fread(RAM + start, 1, 65536-start, prg_file);
+				uint16_t end = start + fread(RAM + start, 1, 0x9f00-start, prg_file);
+				readBanked(prg_file, 0xa000);
 				fclose(prg_file);
 				prg_file = NULL;
 				if (start == 0x0801) {


### PR DESCRIPTION
This allows to load big PRG files, which then will be loaded
into the banked RAM area, if it reaches the end of the BASIC RAM
area. This allows easier program distribution without many small
files. Example app:
http://www.frank-buss.de/x16/mode7-full.prg
Both load functions are changed: -prg and when using LOAD from BASIC.
The native LOAD function with IEC will follow in the ROM repository,
when I found a way to test it.