### PR TITLE
Fix issue #174: POKE $9FB3,X should change emulator echo behavior

### DIFF
--- a/glue.h
+++ b/glue.h
@@ -50,7 +50,7 @@ extern uint16_t num_ram_banks;
 extern bool debugger_enabled;
 extern bool log_video;
 extern bool log_keyboard;
-echo_mode_t echo_mode;
+extern echo_mode_t echo_mode;
 extern bool save_on_exit;
 extern gif_recorder_state_t record_gif;
 extern char *gif_path;

--- a/memory.c
+++ b/memory.c
@@ -203,7 +203,7 @@ emu_write(uint8_t reg, uint8_t value)
 		case 0: debugger_enabled = v; break;
 		case 1: log_video = v; break;
 		case 2: log_keyboard = v; break;
-		case 3: echo_mode = v; break;
+		case 3: echo_mode = value; break;
 		case 4: save_on_exit = v; break;
 		case 5: emu_recorder_set((gif_recorder_command_t) value); break;
 		default: printf("WARN: Invalid register %x\n", DEVICE_EMULATOR + reg);


### PR DESCRIPTION
This should fix https://github.com/commanderx16/x16-emulator/issues/174. I had to change also glue.h and that might affect EMSCRIPTEN version, but I don't know if it does so negatively, but maybe the developers of the emscripten version could check: @Tmp2k @sebastianvog