### PR TITLE
Fix SYS bug on autorun

### DIFF
--- a/main.c
+++ b/main.c
@@ -1027,7 +1027,7 @@ emulator_loop(void *param)
 						paste_text = "RUN\r";
 					} else {
 						paste_text = paste_text_data;
-						snprintf(paste_text, sizeof(paste_text_data), "SYS$%04x\r", start);
+						snprintf(paste_text, sizeof(paste_text_data), "SYS%d\r", start);
 					}
 				}
 			}


### PR DESCRIPTION
Fixed the SYS call which used %x ; this generated L/C call addresses ; simplified to %d