### PR TITLE
Switch viewed ram/rom bank with numpad + and numpad -.

### DIFF
--- a/debugger.c
+++ b/debugger.c
@@ -73,6 +73,8 @@ static void DEBUGExecCmd();
 #define DBGKEY_SETBRK 	SDLK_F9									// F9 sets breakpoint
 #define DBGKEY_STEP 	SDLK_F11 								// F11 is step into.
 #define DBGKEY_STEPOVER	SDLK_F10 								// F10 is step over.
+#define DBGKEY_PAGE_NEXT	SDLK_KP_PLUS
+#define DBGKEY_PAGE_PREV	SDLK_KP_MINUS
 
 #define DBGSCANKEY_BRK 	SDL_SCANCODE_F12 						// F12 is break into running code.
 #define DBGSCANKEY_SHOW	SDL_SCANCODE_TAB 						// Show screen key.
@@ -249,6 +251,14 @@ static void DEBUGHandleKeyEvent(SDL_Keycode key,int isShift) {
 			currentPCBank= -1;
 			break;
 
+		case DBGKEY_PAGE_NEXT:
+			currentBank += 1;
+			break;
+
+		case DBGKEY_PAGE_PREV:
+			currentBank -= 1;
+			break;
+
 		case SDLK_PAGEDOWN:
 			currentData= (currentData + 0xD0) & 0xFFFF;
 			break;
@@ -419,7 +429,7 @@ static void DEBUGRenderCmdLine(int x, int width, int height) {
 
 static void DEBUGRenderData(int y,int data) {
 	while (y < DBG_HEIGHT-2) {									// To bottom of screen
-		DEBUGAddress(DBG_MEMX, y, currentBank, data & 0xFFFF, col_label);	// Show label.
+		DEBUGAddress(DBG_MEMX, y, (uint8_t)currentBank, data & 0xFFFF, col_label);	// Show label.
 
 		for (int i = 0;i < 8;i++) {
 			int byte= real_read6502((data+i) & 0xFFFF, true, currentBank);

--- a/memory.c
+++ b/memory.c
@@ -70,7 +70,7 @@ real_read6502(uint16_t address, bool debugOn, uint8_t bank)
 			return mouse_read(address & 0x1f);
 		} else if (address >= 0x9fb0 && address < 0x9fc0) {
 			// emulator state
-			return emu_read(address & 0xf);
+			return emu_read(address & 0xf, debugOn);
 		} else {
 			return 0;
 		}
@@ -211,7 +211,7 @@ emu_write(uint8_t reg, uint8_t value)
 }
 
 uint8_t
-emu_read(uint8_t reg)
+emu_read(uint8_t reg, bool debugOn)
 {
 	if (reg == 0) {
 		return debugger_enabled ? 1 : 0;
@@ -232,6 +232,6 @@ emu_read(uint8_t reg)
 	} else if (reg == 15) {
 		return '6'; // emulator detection
 	}
-	printf("WARN: Invalid register %x\n", DEVICE_EMULATOR + reg);
+	if (!debugOn) printf("WARN: Invalid register %x\n", DEVICE_EMULATOR + reg);
 	return -1;
 }

--- a/memory.h
+++ b/memory.h
@@ -22,7 +22,7 @@ void memory_set_rom_bank(uint8_t bank);
 uint8_t memory_get_ram_bank();
 uint8_t memory_get_rom_bank();
 
-uint8_t emu_read(uint8_t reg);
+uint8_t emu_read(uint8_t reg, bool debugOn);
 void emu_write(uint8_t reg, uint8_t value);
 
 #endif


### PR DESCRIPTION
Switch viewed ram/rom bank with numpad + and numpad -.
Nicer formatting for current rom bank.
Stop printf printing messages when viewing memory area  0x9fb0- 0x9fc0 in the debugger.