### PR TITLE
Do not set compositor bypass hint for SDL Window

### DIFF
--- a/main.c
+++ b/main.c
@@ -763,6 +763,12 @@ main(int argc, char **argv)
 		paste_text = "GEOS\r";
 	}
 
+#ifdef SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR
+	// Don't disable compositing (on KDE for example)
+	// Available since SDL 2.0.8
+	SDL_SetHint(SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, "0");
+#endif
+
 	SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER
 #ifdef WITH_YM2151
 		| SDL_INIT_AUDIO


### PR DESCRIPTION
I happen to be trying out the KDE desktop on Ubuntu 18.04 today.

SDL2 sets a hint that disables the KDE compositor which results in desktop glitching at startup and shutdown.  I found this a poor experience, but possibly what you'd want on a slow/cheap system or in fullscreen mode, to maximise performance.

This code change works for me.  The alternative in KDE is to disable this _globally_ or whitelist the application to specifically ignore the hint.

![Screenshot_20191201_220203](https://user-images.githubusercontent.com/545677/69913650-4ee49d80-1486-11ea-8473-8d99cdbb007e.png)


