### PR TITLE
Fix a valgrind UMR concerning optimised line rendering

### DIFF
--- a/video.c
+++ b/video.c
@@ -645,9 +645,7 @@ render_line(uint16_t y)
 
 	uint8_t border_color = reg_composer[3];
 	uint16_t hstart = reg_composer[4] | (reg_composer[8] & 3) << 8;
-	uint16_t hstop = reg_composer[5] | ((reg_composer[8] >> 2) & 3) << 8;
 	uint16_t vstart = reg_composer[6] | ((reg_composer[8] >> 4) & 1) << 8;
-	uint16_t vstop = reg_composer[7] | ((reg_composer[8] >> 5) & 1) << 8;
 
 	int eff_y = (reg_composer[2] * (y - vstart)) / 128;
 	render_sprite_line(eff_y);
@@ -655,6 +653,7 @@ render_line(uint16_t y)
 	render_layer_line(1, eff_y);
 
 	uint8_t col_line[SCREEN_WIDTH];
+	memset(col_line, border_color, SCREEN_WIDTH);
 
 	if (video_palette.dirty) {
 		refresh_palette();
@@ -743,14 +742,6 @@ render_line(uint16_t y)
 			}
 		}
 
-		// Add border after if required.
-		if (hstart > 0 || hstop < SCREEN_WIDTH || vstart > 0 || vstop < SCREEN_HEIGHT) {
-			for (uint16_t x = 0; x < SCREEN_WIDTH; x++) {
-				if (x < hstart || x > hstop || y < vstart || y > vstop) {
-					col_line[x] = border_color;
-				}
-			}
-		}
 	}
 
 	// Look up all color indices.


### PR DESCRIPTION
valgrind warning is seen for first call to `render_line`
I didn't quite pinpoint the root cause.
memset resolves the warning, possibly faster than the loop?

Before:
```
==27458== Use of uninitialised value of size 8
==27458==    at 0x1133CB: render_line (video.c:761)
==27458==    by 0x123EA7: video_step (video.c:797)
==27458==    by 0x128695: emulator_loop (main.c:919)
==27458==    by 0x10EC31: main (main.c:788)
```

After:
```
==27041== Memcheck, a memory error detector
==27041== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==27041== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==27041== Command: ./x16emu -rom rom.bin -scale 2 -prg petdrawx16.prg
==27041== 
==27041== 
==27041== HEAP SUMMARY:
==27041==     in use at exit: 631,731 bytes in 560 blocks
==27041==   total heap usage: 40,095 allocs, 39,535 frees, 455,145,124 bytes allocated
==27041== 
==27041== LEAK SUMMARY:
==27041==    definitely lost: 8,376 bytes in 6 blocks
==27041==    indirectly lost: 1,728 bytes in 38 blocks
==27041==      possibly lost: 0 bytes in 0 blocks
==27041==    still reachable: 621,627 bytes in 516 blocks
==27041==         suppressed: 0 bytes in 0 blocks
==27041== Rerun with --leak-check=full to see details of leaked memory
==27041== 
==27041== For counts of detected and suppressed errors, rerun with: -v
==27041== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 5 from 1)
``