### PR TITLE
Switch file operations to use SDL

### DIFF
--- a/loadsave.c
+++ b/loadsave.c
@@ -8,6 +8,7 @@
 #include <sys/stat.h>
 #include <dirent.h>
 #include <unistd.h>
+#include <SDL.h>
 #include "glue.h"
 #include "memory.h"
 #include "video.h"
@@ -132,15 +133,17 @@ LOAD()
 		RAM[STATUS] = 0;
 		a = 0;
 	} else {
-		FILE *f = fopen(filename, "rb");
+		SDL_RWops *f = SDL_RWFromFile(filename, "rb");
 		if (!f) {
 			a = 4; // FNF
 			RAM[STATUS] = a;
 			status |= 1;
 			return;
 		}
-		uint8_t start_lo = fgetc(f);
-		uint8_t start_hi = fgetc(f);
+		uint8_t start_lo;
+		SDL_RWread(f, &start_lo, sizeof(start_lo), 1);
+		uint8_t start_hi;
+        SDL_RWread(f, &start_hi, sizeof(start_hi), 1);
 		uint16_t start;
 		if (!RAM[SA]) {
 			start = override_start;
@@ -156,7 +159,7 @@ LOAD()
 			video_write(2, ((a - 2) & 0xf) | 0x10);
 			uint8_t buf[2048];
 			while(1) {
-				size_t n = fread(buf, 1, sizeof buf, f);
+				size_t n = SDL_RWread(f, buf, 1, sizeof buf);
 				if(n == 0) break;
 				for(size_t i = 0; i < n; i++) {
 					video_write(3, buf[i]);
@@ -165,14 +168,14 @@ LOAD()
 			}
 		} else if(start < 0x9f00) {
 			// Fixed RAM
-			bytes_read = fread(RAM + start, 1, 0x9f00 - start, f);
+			bytes_read = SDL_RWread(f, RAM + start, 1, 0x9f00 - start);
 		} else if(start < 0xa000) {
 			// IO addresses
 		} else if(start < 0xc000) {
 			// banked RAM
 			while(1) {
 				size_t len = 0xc000 - start;
-				bytes_read = fread(RAM + ((uint16_t)memory_get_ram_bank() << 13) + start, 1, len, f);
+				bytes_read = SDL_RWread(f, RAM + ((uint16_t)memory_get_ram_bank() << 13) + start, 1, len);
 				if(bytes_read < len) break;
 
 				// Wrap into the next bank
@@ -183,7 +186,7 @@ LOAD()
 			// ROM
 		}
 
-		fclose(f);
+	    SDL_RWclose(f);
 
 		uint16_t end = start + bytes_read;
 		x = end & 0xff;
@@ -210,7 +213,7 @@ SAVE()
 		return;
 	}
 
-	FILE *f = fopen(filename, "wb");
+	SDL_RWops *f = SDL_RWFromFile(filename, "wb");
 	if (!f) {
 		a = 4; // FNF
 		RAM[STATUS] = a;
@@ -218,11 +221,13 @@ SAVE()
 		return;
 	}
 
-	fputc(start & 0xff, f);
-	fputc(start >> 8, f);
+	char c = start & 0xff;
+	SDL_RWwrite(f, &c, sizeof(c), 1);
+	c = start >> 8;+
+    SDL_RWwrite(f, &c, sizeof(c), 1);
 
-	fwrite(RAM + start, 1, end - start, f);
-	fclose(f);
+	SDL_RWwrite(f, RAM + start, 1, end - start);
+	SDL_RWclose(f);
 
 	status &= 0xfe;
 	RAM[STATUS] = 0;

--- a/loadsave.c
+++ b/loadsave.c
@@ -223,7 +223,7 @@ SAVE()
 
 	char c = start & 0xff;
 	SDL_RWwrite(f, &c, sizeof(c), 1);
-	c = start >> 8;+
+	c = start >> 8;
     SDL_RWwrite(f, &c, sizeof(c), 1);
 
 	SDL_RWwrite(f, RAM + start, 1, end - start);

--- a/memory.c
+++ b/memory.c
@@ -130,13 +130,13 @@ write6502(uint16_t address, uint8_t value)
 //
 
 void
-memory_save(FILE *f, bool dump_ram, bool dump_bank)
+memory_save(SDL_RWops *f, bool dump_ram, bool dump_bank)
 {
 	if (dump_ram) {
-		fwrite(&RAM[0], sizeof(uint8_t), 0xa000, f);
+		SDL_RWwrite(f, &RAM[0], sizeof(uint8_t), 0xa000);
 	}
 	if (dump_bank) {
-		fwrite(&RAM[0xa000], sizeof(uint8_t), (num_ram_banks * 8192), f);
+		SDL_RWwrite(f, &RAM[0xa000], sizeof(uint8_t), (num_ram_banks * 8192));
 	}
 }
 

--- a/memory.h
+++ b/memory.h
@@ -8,13 +8,14 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <SDL.h>
 
 uint8_t read6502(uint16_t address);
 uint8_t real_read6502(uint16_t address, bool debugOn, uint8_t bank);
 
 void memory_init();
 
-void memory_save(FILE *f, bool dump_ram, bool dump_bank);
+void memory_save(SDL_RWops *f, bool dump_ram, bool dump_bank);
 
 void memory_set_ram_bank(uint8_t bank);
 void memory_set_rom_bank(uint8_t bank);

--- a/sdcard.c
+++ b/sdcard.c
@@ -6,7 +6,7 @@
 #include "sdcard.h"
 
 static int cmd_receive_counter;
-FILE *sdcard_file = NULL;
+SDL_RWops *sdcard_file = NULL;
 
 void
 sdcard_select()
@@ -84,8 +84,8 @@ sdcard_handle(uint8_t inbyte)
 					read_block_respose[0] = 0;
 					read_block_respose[1] = 0xfe;
 //					printf("Reading LBA %d\n", lba);
-					fseek(sdcard_file, lba * 512, SEEK_SET);
-					int bytes_read = fread(&read_block_respose[2], 1, 512, sdcard_file);
+					SDL_RWseek(sdcard_file, lba * 512, SEEK_SET);
+                    size_t bytes_read = SDL_RWread(sdcard_file, &read_block_respose[2], 1, 512);
 					if (bytes_read != 512) {
 						printf("Warning: short read!\n");
 					}

--- a/sdcard.h
+++ b/sdcard.h
@@ -4,8 +4,9 @@
 #ifndef _SD_CARD_H_
 #define _SD_CARD_H_
 #include <inttypes.h>
+#include <SDL.h>
 
-extern FILE *sdcard_file;
+extern SDL_RWops *sdcard_file;
 
 void sdcard_select();
 uint8_t sdcard_handle(uint8_t inbyte);

--- a/vera_uart.h
+++ b/vera_uart.h
@@ -4,8 +4,8 @@
 
 #include <inttypes.h>
 
-extern FILE *uart_in_file;
-extern FILE *uart_out_file;
+extern SDL_RWops *uart_in_file;
+extern SDL_RWops *uart_out_file;
 
 void vera_uart_init();
 void vera_uart_step();

--- a/video.c
+++ b/video.c
@@ -828,14 +828,14 @@ video_get_irq_out()
 //
 
 void
-video_save(FILE *f)
+video_save(SDL_RWops *f)
 {
-	fwrite(&video_ram[0], sizeof(uint8_t), sizeof(video_ram), f);
-	fwrite(&reg_composer[0], sizeof(uint8_t), sizeof(reg_composer), f);
-	fwrite(&palette[0], sizeof(uint8_t), sizeof(palette), f);
-	fwrite(&reg_layer[0][0], sizeof(uint8_t), sizeof(reg_layer), f);
-	fwrite(&reg_sprites[0], sizeof(uint8_t), sizeof(reg_sprites), f);
-	fwrite(&sprite_data[0], sizeof(uint8_t), sizeof(sprite_data), f);
+	SDL_RWwrite(f, &video_ram[0], sizeof(uint8_t), sizeof(video_ram));
+	SDL_RWwrite(f, &reg_composer[0], sizeof(uint8_t), sizeof(reg_composer));
+	SDL_RWwrite(f, &palette[0], sizeof(uint8_t), sizeof(palette));
+	SDL_RWwrite(f, &reg_layer[0][0], sizeof(uint8_t), sizeof(reg_layer));
+	SDL_RWwrite(f, &reg_sprites[0], sizeof(uint8_t), sizeof(reg_sprites));
+	SDL_RWwrite(f, &sprite_data[0], sizeof(uint8_t), sizeof(sprite_data));
 }
 
 bool

--- a/video.h
+++ b/video.h
@@ -17,7 +17,7 @@ bool video_step(float mhz);
 bool video_update(void);
 void video_end(void);
 bool video_get_irq_out(void);
-void video_save(FILE *f);
+void video_save(SDL_RWops *f);
 uint8_t video_read(uint8_t reg, bool debugOn);
 void video_write(uint8_t reg, uint8_t value);
 void video_update_title(const char* window_title);


### PR DESCRIPTION
This is intended to fix #221, but it has the effect of fixing a few other issues as well, including inconsistency over the encoding of BASIC files. Before merging, it will be necessary to test that all functionality is still working, which is something I'm already working on.

Issue #221 seems fixed by this, as now it is possible to load the ROM from a path containing arbitrary characters.