### PR TITLE
Corrected sound frequencies

### DIFF
--- a/main.c
+++ b/main.c
@@ -464,8 +464,8 @@ init_audio()
 		exit(-1);
 	}
 
-	// init YM2151 emulation. 4 MHz clock
-	YM_Create(4000000);
+	// init YM2151 emulation. twice the 3.579545 MHz chip clock
+	YM_Create(7159090);
 	YM_init(have.freq, 60);
 
 	// start playback


### PR DESCRIPTION
Playing a 440 Hz sound (by writing the value $4A to the YM2151 register $28) did not produce a sound output of the desired frequency, but rather 246 Hz. This was verified using both audacity as well as an external guitar tuner.

According to the YM2151 documentation, frequencies generated are based on the chip clock frequency, which is expected to be 3.579545 MHz.

For some (for me unknown) reason the value needed in line 468 is apparently twice the chip clock frequency. With this single change, the sound output now has the desired frequency, verified in both audacity and an external guitar tuner.