### PR TITLE
Allow High DPI to fix mouse movement calculations. (Close #248)

### DIFF
--- a/video.c
+++ b/video.c
@@ -157,7 +157,7 @@ video_init(int window_scale, char *quality)
 	video_reset();
 
 	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, quality);
-	SDL_CreateWindowAndRenderer(SCREEN_WIDTH * window_scale, SCREEN_HEIGHT * window_scale, 0, &window, &renderer);
+	SDL_CreateWindowAndRenderer(SCREEN_WIDTH * window_scale, SCREEN_HEIGHT * window_scale, SDL_WINDOW_ALLOW_HIGHDPI, &window, &renderer);
 #ifndef __MORPHOS__
 	SDL_SetWindowResizable(window, true);
 #endif


### PR DESCRIPTION
Without the high DPI flag, the mouse moves out of the window
before it reports a high enough mouse position to see the right
half or bottom half of the screen, rendering those portions of
the display unreachable with the mouse on OSX and other
platforms that might use the HighDPI functionality for their
displays.