### PR TITLE
Replacing mults and divs with power-of-two adds.

### DIFF
--- a/video.c
+++ b/video.c
@@ -93,8 +93,10 @@ static uint8_t reg_composer[8];
 static uint8_t layer_line[2][SCREEN_WIDTH];
 static uint8_t sprite_line_col[SCREEN_WIDTH];
 static uint8_t sprite_line_z[SCREEN_WIDTH];
-static bool layer_line_empty[2];
-static bool sprite_line_empty;
+static uint8_t sprite_line_mask[SCREEN_WIDTH];
+static uint8_t sprite_line_collisions;
+static bool layer_line_enable[2];
+static bool sprite_line_enable;
 
 float scan_pos_x;
 uint16_t scan_pos_y;
@@ -153,6 +155,8 @@ video_reset()
 	for (int i = 0; i < 128 * 1024; i++) {
 		video_ram[i] = rand();
 	}
+
+	sprite_line_collisions = 0;
 
 	scan_pos_x = 0;
 	scan_pos_y = 0;
@@ -219,51 +223,60 @@ struct video_layer_properties
 	uint16_t hscroll;
 	uint16_t vscroll;
 
-	uint16_t mapw;
-	uint16_t maph;
+	uint8_t  mapw_log2;
+	uint8_t  maph_log2;
 	uint16_t tilew;
 	uint16_t tileh;
+	uint8_t  tilew_log2;
+	uint8_t  tileh_log2;
 
 	uint16_t mapw_max;
 	uint16_t maph_max;
 	uint16_t tilew_max;
 	uint16_t tileh_max;
-
-	uint16_t layerw;
-	uint16_t layerh;
-
 	uint16_t layerw_max;
 	uint16_t layerh_max;
 
-	uint8_t bits_per_pixel;
-
-	uint32_t tile_size;
+	uint8_t tile_size_log2;
 
 	int min_eff_x;
 	int max_eff_x;
+
+	uint8_t bits_per_pixel;
+	uint8_t first_color_pos;
+	uint8_t color_mask;
+	uint8_t color_fields_max;
 };
 
 struct video_layer_properties layer_properties[2];
 
 static int
-calc_layer_eff_x(struct video_layer_properties *props, int x)
+calc_layer_eff_x(const struct video_layer_properties *props, const int x)
 {
 	return (x + props->hscroll) & (props->layerw_max);
 }
 
 static int
-calc_layer_eff_y(struct video_layer_properties *props, int y)
+calc_layer_eff_y(const struct video_layer_properties *props, const int y)
 {
 	return (y + props->vscroll) & (props->layerh_max);
 }
 
 static uint32_t
-calc_layer_map_addr(struct video_layer_properties *props, int eff_x, int eff_y)
+calc_layer_map_addr_base2(const struct video_layer_properties *props, const int eff_x, const int eff_y)
 {
-	return props->map_base + (eff_y / props->tileh * props->mapw + eff_x / props->tilew) * 2;
+	// Slightly faster on some platforms because we know that tilew and tileh are powers of 2.
+	return props->map_base + ((((eff_y >> props->tileh_log2) << props->mapw_log2) + (eff_x >> props->tilew_log2)) << 1);
 }
 
-void refresh_layer_properties(uint8_t layer)
+//TODO: Unused in all current cases. Delete? Or leave commented as a reminder?
+//static uint32_t
+//calc_layer_map_addr(struct video_layer_properties *props, int eff_x, int eff_y)
+//{
+//	return props->map_base + ((eff_y / props->tileh) * props->mapw + (eff_x / props->tilew)) * 2;
+//}
+static void
+refresh_layer_properties(const uint8_t layer)
 {
 	struct video_layer_properties* props = &layer_properties[layer];
 
@@ -286,36 +299,37 @@ void refresh_layer_properties(uint8_t layer)
 		props->vscroll = 0;
 	}
 
-	props->mapw = 0;
-	props->maph = 0;
+	uint16_t mapw = 0;
+	uint16_t maph = 0;
 	props->tilew = 0;
 	props->tileh = 0;
 
 	if (props->tile_mode || props->text_mode) {
-		props->mapw = 1 << (((reg_layer[layer][0] >> 4) & 3) + 5);
-		props->maph = 1 << (((reg_layer[layer][0] >> 6) & 3) + 5);
+		props->mapw_log2 = 5 + ((reg_layer[layer][0] >> 4) & 3);
+		props->maph_log2 = 5 + ((reg_layer[layer][0] >> 6) & 3);
+		mapw      = 1 << props->mapw_log2;
+		maph      = 1 << props->maph_log2;
+
 		// Scale the tiles or text characters according to TILEW and TILEH.
-		props->tilew = 1 << ((reg_layer[layer][2] & 1) + 3);
-		props->tileh = 1 << (((reg_layer[layer][2] >> 1) & 1) + 3);
+		props->tilew_log2 = 3 + (reg_layer[layer][2] & 1);
+		props->tileh_log2 = 3 + ((reg_layer[layer][2] >> 1) & 1);
+		props->tilew      = 1 << props->tilew_log2;
+		props->tileh      = 1 << props->tileh_log2;
 	} else if (props->bitmap_mode) {
 		// bitmap mode is basically tiled mode with a single huge tile
 		props->tilew = (reg_layer[layer][2] & 1) ? 640 : 320;
 		props->tileh = SCREEN_HEIGHT;
 	}
 
-	// We know mapw, maph, tilew, and tileh are powers of two, and any products of that set will be powers of two,
+	// We know mapw, maph, tilew, and tileh are powers of two in all cases except bitmap modes, and any products of that set will be powers of two,
 	// so there's no need to modulo against them if we have bitmasks we can bitwise-and against.
 
-	props->mapw_max = props->mapw - 1;
-	props->maph_max = props->maph - 1;
+	props->mapw_max = mapw - 1;
+	props->maph_max = maph - 1;
 	props->tilew_max = props->tilew - 1;
 	props->tileh_max = props->tileh - 1;
-
-	props->layerw = props->mapw * props->tilew;
-	props->layerh = props->maph * props->tileh;
-
-	props->layerw_max = props->layerw - 1;
-	props->layerh_max = props->layerh - 1;
+	props->layerw_max = (mapw * props->tilew) - 1;
+	props->layerh_max = (maph * props->tileh) - 1;
 
 	// Find min/max eff_x for bulk reading in tile data during draw.
 	if (prev_layerw_max != props->layerw_max || prev_hscroll != props->hscroll) {
@@ -335,22 +349,29 @@ void refresh_layer_properties(uint8_t layer)
 	}
 
 	props->bits_per_pixel = 1 << props->color_depth;
-	props->tile_size = (props->tilew * props->bits_per_pixel * props->tileh) >> 3;
+	props->tile_size_log2 = props->tilew_log2 + props->tileh_log2 + props->color_depth - 3;
+
+	props->first_color_pos  = 8 - props->bits_per_pixel;
+	props->color_mask       = (1 << props->bits_per_pixel) - 1;
+	props->color_fields_max = (8 >> props->color_depth) - 1;
 }
 
 struct video_sprite_properties
 {
 	int8_t sprite_zdepth;
+	uint8_t sprite_collision_mask;
 
 	int16_t sprite_x;
 	int16_t sprite_y;
+	uint8_t sprite_width_log2;
+	uint8_t sprite_height_log2;
 	uint8_t sprite_width;
 	uint8_t sprite_height;
 
 	bool hflip;
 	bool vflip;
 
-	bool mode;
+	uint8_t color_mode;
 	uint32_t sprite_address;
 
 	uint16_t palette_offset;
@@ -358,16 +379,20 @@ struct video_sprite_properties
 
 struct video_sprite_properties sprite_properties[128];
 
-void refresh_sprite_properties(uint16_t sprite)
+static void
+refresh_sprite_properties(const uint16_t sprite)
 {
 	struct video_sprite_properties* props = &sprite_properties[sprite];
 
 	props->sprite_zdepth = (sprite_data[sprite][6] >> 2) & 3;
+	props->sprite_collision_mask = sprite_data[sprite][6] & 0xf0;
 
 	props->sprite_x = sprite_data[sprite][2] | (sprite_data[sprite][3] & 3) << 8;
 	props->sprite_y = sprite_data[sprite][4] | (sprite_data[sprite][5] & 3) << 8;
-	props->sprite_width = 1 << (((sprite_data[sprite][7] >> 4) & 3) + 3);
-	props->sprite_height = 1 << ((sprite_data[sprite][7] >> 6) + 3);
+	props->sprite_width_log2  = (((sprite_data[sprite][7] >> 4) & 3) + 3);
+	props->sprite_height_log2 = ((sprite_data[sprite][7] >> 6) + 3);
+	props->sprite_width       = 1 << props->sprite_width_log2;
+	props->sprite_height      = 1 << props->sprite_height_log2;
 
 	// fix up negative coordinates
 	if (props->sprite_x >= 0x400 - props->sprite_width) {
@@ -380,7 +405,7 @@ void refresh_sprite_properties(uint16_t sprite)
 	props->hflip = sprite_data[sprite][6] & 1;
 	props->vflip = (sprite_data[sprite][6] >> 1) & 1;
 
-	props->mode = (sprite_data[sprite][1] >> 7) & 1;
+	props->color_mode     = (sprite_data[sprite][1] >> 7) & 1;
 	props->sprite_address = sprite_data[sprite][0] << 5 | (sprite_data[sprite][1] & 0xf) << 13;
 
 	props->palette_offset = (sprite_data[sprite][7] & 0x0f) << 4;
@@ -394,9 +419,10 @@ struct video_palette
 
 struct video_palette video_palette;
 
-static void refresh_palette() {
-	uint8_t out_mode = reg_composer[0] & 3;
-	bool chroma_disable = (reg_composer[0] >> 2) & 1;
+static void
+refresh_palette() {
+	const uint8_t out_mode = reg_composer[0] & 3;
+	const bool chroma_disable = (reg_composer[0] >> 2) & 1;
 	for (int i = 0; i < 256; ++i) {
 		uint8_t r;
 		uint8_t g;
@@ -423,23 +449,31 @@ static void refresh_palette() {
 }
 
 static void
-render_sprite_line(uint16_t y)
+expand_4bpp_data(uint8_t *dst, const uint8_t *src, int dst_size)
 {
-	if (!(reg_composer[0] & 0x40)) {
-		// sprites disabled
-		sprite_line_empty = true;
-		return;
+	while (dst_size >= 2) {
+		*dst = (*src) >> 4;
+		++dst;
+		*dst = (*src) & 0xf;
+		++dst;
+
+		++src;
+		dst_size -= 2;
 	}
-	sprite_line_empty = false;
-	for (int i = 0; i < SCREEN_WIDTH; i++) {
-		sprite_line_col[i] = 0;
-		sprite_line_z[i] = 0;
-	}
+}
+
+static void
+render_sprite_line(const uint16_t y)
+{
+	memset(sprite_line_col, 0, SCREEN_WIDTH);
+	memset(sprite_line_z, 0, SCREEN_WIDTH);
+	memset(sprite_line_mask, 0, SCREEN_WIDTH);
+
 	uint16_t sprite_budget = 800 + 1;
 	for (int i = 0; i < NUM_SPRITES; i++) {
 		// one clock per lookup
 		sprite_budget--; if (sprite_budget == 0) break;
-		struct video_sprite_properties *props = &sprite_properties[i];
+		const struct video_sprite_properties *props = &sprite_properties[i];
 
 		if (props->sprite_zdepth == 0) {
 			continue;
@@ -450,50 +484,47 @@ render_sprite_line(uint16_t y)
 			continue;
 		}
 
-		for (uint16_t sx = 0; sx < props->sprite_width; sx++) {
-			uint16_t line_x = props->sprite_x + sx;
+		const uint16_t eff_sy = props->vflip ? ((props->sprite_height - 1) - (y - props->sprite_y)) : (y - props->sprite_y);
+
+		int16_t       eff_sx      = (props->hflip ? (props->sprite_width - 1) : 0);
+		const int16_t eff_sx_incr = props->hflip ? -1 : 1;
+
+		const uint8_t *bitmap_data = video_ram + props->sprite_address + (eff_sy << (props->sprite_width_log2 - (1 - props->color_mode)));
+
+		uint8_t unpacked_sprite_line[64];
+		if (props->color_mode == 0) {
+			// 4bpp
+			expand_4bpp_data(unpacked_sprite_line, bitmap_data, props->sprite_width);
+		} else {
+			// 8bpp
+			memcpy(unpacked_sprite_line, bitmap_data, props->sprite_width);
+		}
+		
+		for (uint16_t sx = 0; sx < props->sprite_width; ++sx) {
+			const uint16_t line_x = props->sprite_x + sx;
 			if (line_x >= SCREEN_WIDTH) {
+				eff_sx += eff_sx_incr;
 				continue;
-			}
-			uint16_t eff_sx = sx;
-			uint16_t eff_sy = y - props->sprite_y;
-
-			// flip
-			if (props->hflip) {
-				eff_sx = (props->sprite_width - 1) - eff_sx;
-			}
-			if (props->vflip) {
-				eff_sy = (props->sprite_height - 1) - eff_sy;
-			}
-
-			uint8_t col_index = 0;
-			uint32_t vaddr;
-			if (props->mode == 0) {
-				// 4 bpp
-				vaddr = props->sprite_address + (eff_sy * props->sprite_width >> 1) + (eff_sx >> 1);
-				uint8_t byte = video_ram[vaddr];
-				if (eff_sx & 1) {
-					col_index = byte & 0xf;
-				} else {
-					col_index = byte >> 4;
-				}
-			} else {
-				// 8 bpp
-				vaddr = props->sprite_address + eff_sy * props->sprite_width + eff_sx;
-				col_index = video_ram[vaddr];
 			}
 
 			// one clock per fetched 32 bits
-			if (!(vaddr & 3)) {
+			if (!(sx & 3)) {
 				sprite_budget--; if (sprite_budget == 0) break;
 			}
+
 			// one clock per rendered pixel
 			sprite_budget--; if (sprite_budget == 0) break;
+
+			const uint8_t col_index = unpacked_sprite_line[eff_sx];
+			eff_sx += eff_sx_incr;
+
 			// palette offset
 			if (col_index > 0) {
-				col_index += props->palette_offset;
-				if (props->sprite_zdepth > sprite_line_z[line_x]) {
-					sprite_line_col[line_x] = col_index;
+				sprite_line_collisions |= sprite_line_mask[line_x] & props->sprite_collision_mask;
+				sprite_line_mask[line_x] |= props->sprite_collision_mask;
+
+        if (props->sprite_zdepth > sprite_line_z[line_x]) {
+					sprite_line_col[line_x] = col_index + props->palette_offset;
 					sprite_line_z[line_x] = props->sprite_zdepth;
 				}
 			}
@@ -502,126 +533,247 @@ render_sprite_line(uint16_t y)
 }
 
 static void
-render_layer_line(uint8_t layer, uint16_t y)
+render_layer_line_text(uint8_t layer, uint16_t y)
+{
+	const struct video_layer_properties *props = &layer_properties[layer];
+
+	const uint8_t max_pixels_per_byte = (8 >> props->color_depth) - 1;
+	const int     eff_y               = calc_layer_eff_y(props, y);
+	const int     yy                  = eff_y & props->tileh_max;
+
+	// additional bytes to reach the correct line of the tile
+	const uint32_t y_add = (yy << props->tilew_log2) >> 3;
+
+	const uint32_t map_addr_begin = calc_layer_map_addr_base2(props, props->min_eff_x, eff_y);
+	const uint32_t map_addr_end   = calc_layer_map_addr_base2(props, props->max_eff_x, eff_y);
+	const int      size           = (map_addr_end - map_addr_begin) + 2;
+
+	uint8_t tile_bytes[512]; // max 256 tiles, 2 bytes each.
+	video_space_read_range(tile_bytes, map_addr_begin, size);
+
+	uint32_t tile_start;
+
+	uint8_t  fg_color;
+	uint8_t  bg_color;
+	uint8_t  s;
+	uint8_t  color_shift;
+
+	{
+		const int eff_x = calc_layer_eff_x(props, 0);
+		const int xx    = eff_x & props->tilew_max;
+
+		// extract all information from the map
+		const uint32_t map_addr = calc_layer_map_addr_base2(props, eff_x, eff_y) - map_addr_begin;
+
+		const uint8_t tile_index = tile_bytes[map_addr];
+		const uint8_t byte1      = tile_bytes[map_addr + 1];
+
+		if (!props->text_mode_256c) {
+			fg_color = byte1 & 15;
+			bg_color = byte1 >> 4;
+		} else {
+			fg_color = byte1;
+			bg_color = 0;
+		}
+
+		// offset within tilemap of the current tile
+		tile_start = tile_index << props->tile_size_log2;
+
+		// additional bytes to reach the correct column of the tile
+		const uint16_t x_add       = xx >> 3;
+		const uint32_t tile_offset = tile_start + y_add + x_add;
+
+		s           = video_space_read(props->tile_base + tile_offset);
+		color_shift = max_pixels_per_byte - xx;
+	}
+
+	// Render tile line.
+	for (int x = 0; x < SCREEN_WIDTH; x++) {
+		// Scrolling
+		const int eff_x = calc_layer_eff_x(props, x);
+		const int xx = eff_x & props->tilew_max;
+
+		if ((eff_x & 0x7) == 0) {
+			if ((eff_x & props->tilew_max) == 0) {
+				// extract all information from the map
+				const uint32_t map_addr = calc_layer_map_addr_base2(props, eff_x, eff_y) - map_addr_begin;
+
+				const uint8_t tile_index = tile_bytes[map_addr];
+				const uint8_t byte1      = tile_bytes[map_addr + 1];
+
+				if (!props->text_mode_256c) {
+					fg_color = byte1 & 15;
+					bg_color = byte1 >> 4;
+				} else {
+					fg_color = byte1;
+					bg_color = 0;
+				}
+
+				// offset within tilemap of the current tile
+				tile_start = tile_index << props->tile_size_log2;
+			}
+
+			// additional bytes to reach the correct column of the tile
+			const uint16_t x_add       = xx >> 3;
+			const uint32_t tile_offset = tile_start + y_add + x_add;
+
+			s           = video_space_read(props->tile_base + tile_offset);
+			color_shift = max_pixels_per_byte;
+		}
+
+		// convert tile byte to indexed color
+		const uint8_t col_index = (s >> color_shift) & 1;
+		--color_shift;
+		layer_line[layer][x] = col_index ? fg_color : bg_color;
+	}
+}
+
+static void
+render_layer_line_tile(uint8_t layer, uint16_t y)
 {
 	struct video_layer_properties *props = &layer_properties[layer];
 
-	bool enabled = (reg_composer[0] & (layer ? 0x20 : 0x10)) != 0;
+	const uint8_t max_pixels_per_byte = (8 >> props->color_depth) - 1;
+	const int     eff_y               = calc_layer_eff_y(props, y);
+	const uint8_t yy                  = eff_y & props->tileh_max;
+	const uint8_t yy_flip             = yy ^ props->tileh_max;
+	const uint32_t y_add              = (yy << (props->tilew_log2 + props->color_depth - 3));
+	const uint32_t y_add_flip         = (yy_flip << (props->tilew_log2 + props->color_depth - 3));
 
-	if (!enabled) {
-		layer_line_empty[layer] = true;
-	} else {
-		layer_line_empty[layer] = false;
+	const uint32_t map_addr_begin = calc_layer_map_addr_base2(props, props->min_eff_x, eff_y);
+	const uint32_t map_addr_end   = calc_layer_map_addr_base2(props, props->max_eff_x, eff_y);
+	const int      size           = (map_addr_end - map_addr_begin) + 2;
 
-		// Load in tile bytes if not in bitmap mode.
-		uint8_t tile_bytes[512]; // max 256 tiles, 2 bytes each.
-		uint32_t map_addr_begin = 0;
-		uint32_t map_addr_end = 0;
+	uint8_t tile_bytes[512]; // max 256 tiles, 2 bytes each.
+	video_space_read_range(tile_bytes, map_addr_begin, size);
 
-		if (!props->bitmap_mode) {
-			int size;
-			int eff_y = calc_layer_eff_y(props, y);
-			map_addr_begin = calc_layer_map_addr(props, props->min_eff_x, eff_y);
-			map_addr_end = calc_layer_map_addr(props, props->max_eff_x, eff_y);
-			size = (map_addr_end - map_addr_begin) + 2;
+	uint8_t  palette_offset;
+	bool     vflip;
+	bool     hflip;
+	uint32_t tile_start;
+	uint8_t  s;
+	uint8_t  color_shift;
+	int8_t   color_shift_incr;
 
-			video_space_read_range(tile_bytes, map_addr_begin, size);
+	{
+		const int eff_x = calc_layer_eff_x(props, 0);
+
+		// extract all information from the map
+		const uint32_t map_addr = calc_layer_map_addr_base2(props, eff_x, eff_y) - map_addr_begin;
+
+		const uint8_t byte0 = tile_bytes[map_addr];
+		const uint8_t byte1 = tile_bytes[map_addr + 1];
+
+		// Tile Flipping
+		vflip = (byte1 >> 3) & 1;
+		hflip = (byte1 >> 2) & 1;
+
+		palette_offset = byte1 & 0xf0;
+
+		// offset within tilemap of the current tile
+		const uint16_t tile_index = byte0 | ((byte1 & 3) << 8);
+		tile_start                = tile_index << props->tile_size_log2;
+
+		color_shift_incr = hflip ? props->bits_per_pixel : -props->bits_per_pixel;
+
+		int xx = eff_x & props->tilew_max;
+		if (hflip) {
+			xx          = xx ^ (props->tilew_max);
+			color_shift = 0;
+		} else {
+			color_shift = props->first_color_pos;
 		}
 
-		// Render tile line.
-		for (int x = 0; x < SCREEN_WIDTH; x++) {
-			uint8_t col_index = 0;
-			int xx, yy;
+		// additional bytes to reach the correct column of the tile
+		uint16_t x_add       = (xx << props->color_depth) >> 3;
+		uint32_t tile_offset = tile_start + (vflip ? y_add_flip : y_add) + x_add;
 
-			int eff_x = x;
-			int eff_y = y;
+		s = video_space_read(props->tile_base + tile_offset);
+	}
 
-			// Scrolling
-			if (!props->bitmap_mode) {
-				eff_x = calc_layer_eff_x(props, x);
-				eff_y = calc_layer_eff_y(props, y);
+
+	// Render tile line.
+	for (int x = 0; x < SCREEN_WIDTH; x++) {
+		const int eff_x = calc_layer_eff_x(props, x);
+
+		if ((eff_x & max_pixels_per_byte) == 0) {
+			if ((eff_x & props->tilew_max) == 0) {
+				// extract all information from the map
+				const uint32_t map_addr = calc_layer_map_addr_base2(props, eff_x, eff_y) - map_addr_begin;
+
+				const uint8_t byte0 = tile_bytes[map_addr];
+				const uint8_t byte1 = tile_bytes[map_addr + 1];
+
+				// Tile Flipping
+				vflip = (byte1 >> 3) & 1;
+				hflip = (byte1 >> 2) & 1;
+
+				palette_offset = byte1 & 0xf0;
+
+				// offset within tilemap of the current tile
+				const uint16_t tile_index = byte0 | ((byte1 & 3) << 8);
+				tile_start                = tile_index << props->tile_size_log2;
+
+				color_shift_incr = hflip ? props->bits_per_pixel : -props->bits_per_pixel;
 			}
 
-			if (props->bitmap_mode) {
-				xx = eff_x % props->tilew;
-				yy = eff_y % props->tileh;
+			int xx = eff_x & props->tilew_max;
+			if (hflip) {
+				xx = xx ^ (props->tilew_max);
+				color_shift = 0;
 			} else {
-				xx = eff_x & props->tilew_max;
-				yy = eff_y & props->tileh_max;
+				color_shift = props->first_color_pos;
 			}
 
-			uint16_t tile_index = 0;
-			uint8_t fg_color = 0;
-			uint8_t bg_color = 0;
-			uint8_t palette_offset = 0;
-
-			// extract all information from the map
-			if (props->bitmap_mode) {
-				tile_index = 0;
-				palette_offset = reg_layer[layer][4] & 0xf;
-			} else {
-				uint32_t map_addr = calc_layer_map_addr(props, eff_x, eff_y) - map_addr_begin;
-
-				uint8_t byte0 = tile_bytes[map_addr];
-				uint8_t byte1 = tile_bytes[map_addr + 1];
-
-				if (props->text_mode) {
-					tile_index = byte0;
-
-					if (!props->text_mode_256c) {
-						fg_color = byte1 & 15;
-						bg_color = byte1 >> 4;
-					} else {
-						fg_color = byte1;
-						bg_color = 0;
-					}
-				} else if (props->tile_mode) {
-					tile_index = byte0 | ((byte1 & 3) << 8);
-
-					// Tile Flipping
-					bool vflip = (byte1 >> 3) & 1;
-					bool hflip = (byte1 >> 2) & 1;
-					if (vflip) {
-						yy = yy ^ (props->tileh - 1);
-					}
-					if (hflip) {
-						xx = xx ^ (props->tilew - 1);
-					}
-
-					palette_offset = byte1 >> 4;
-				}
-			}
-
-			// offset within tilemap of the current tile
-			uint32_t tile_start = tile_index * props->tile_size;
-			// additional bytes to reach the correct line of the tile
-			uint32_t y_add = (yy * props->tilew * props->bits_per_pixel) >> 3;
 			// additional bytes to reach the correct column of the tile
-			uint16_t x_add = (xx * props->bits_per_pixel) >> 3;
-			uint32_t tile_offset = tile_start + y_add + x_add;
-			uint8_t s = video_space_read(props->tile_base + tile_offset);
+			const uint16_t x_add       = (xx << props->color_depth) >> 3;
+			const uint32_t tile_offset = tile_start + (vflip ? y_add_flip : y_add) + x_add;
 
-			// convert tile byte to indexed color
-			if (props->bits_per_pixel == 1) {
-				col_index = (s >> (7 - (xx & 7))) & 1;
-
-				if (props->text_mode) {
-					col_index = col_index ? fg_color : bg_color;
-				}
-			} else if (props->bits_per_pixel == 2) {
-				col_index = (s >> (6 - ((xx & 3) << 1))) & 3;
-			} else if (props->bits_per_pixel == 4) {
-				col_index = (s >> (4 - ((xx & 1) << 2))) & 0xf;
-			} else if (props->bits_per_pixel == 8) {
-				col_index = s;
-			}
-
-			// Apply Palette Offset
-			if (palette_offset && col_index > 0 && col_index < 16) {
-				col_index += palette_offset << 4;
-			}
-			layer_line[layer][x] = col_index;
+			s = video_space_read(props->tile_base + tile_offset);
 		}
+
+		// convert tile byte to indexed color
+		uint8_t col_index = (s >> color_shift) & props->color_mask;
+		color_shift += color_shift_incr;
+
+		// Apply Palette Offset
+		if (palette_offset && col_index > 0 && col_index < 16) {
+			col_index += palette_offset;
+		}
+		layer_line[layer][x] = col_index;
+	}
+}
+
+
+static void
+render_layer_line_bitmap(uint8_t layer, uint16_t y)
+{
+	struct video_layer_properties *props = &layer_properties[layer];
+
+	int yy = y % props->tileh;
+	// additional bytes to reach the correct line of the tile
+	uint32_t y_add = (yy * props->tilew * props->bits_per_pixel) >> 3;
+
+	// Render tile line.
+	for (int x = 0; x < SCREEN_WIDTH; x++) {
+		int xx = x % props->tilew;
+
+		// extract all information from the map
+		uint8_t palette_offset = reg_layer[layer][4] & 0xf;
+
+		// additional bytes to reach the correct column of the tile
+		uint16_t x_add = (xx * props->bits_per_pixel) >> 3;
+		uint32_t tile_offset = y_add + x_add;
+		uint8_t s = video_space_read(props->tile_base + tile_offset);
+
+		// convert tile byte to indexed color
+		uint8_t col_index = (s >> (props->first_color_pos - ((xx & props->color_fields_max) << props->color_depth))) & props->color_mask;
+
+		// Apply Palette Offset
+		if (palette_offset && col_index > 0 && col_index < 16) {
+			col_index += palette_offset << 4;
+		}
+		layer_line[layer][x] = col_index;
 	}
 }
 
@@ -630,16 +782,16 @@ static uint8_t calculate_line_col_index(uint8_t spr_zindex, uint8_t spr_col_inde
 	uint8_t col_index = 0;
 	switch (spr_zindex) {
 		case 3:
-			col_index = spr_col_index ?: l2_col_index ?: l1_col_index;
+			col_index = spr_col_index ? spr_col_index : (l2_col_index ? l2_col_index : l1_col_index);
 			break;
 		case 2:
-			col_index = l2_col_index ?: spr_col_index ?: l1_col_index;
+			col_index = l2_col_index ? l2_col_index : (spr_col_index ? spr_col_index : l1_col_index);
 			break;
 		case 1:
-			col_index = l2_col_index ?: l1_col_index ?: spr_col_index;
+			col_index = l2_col_index ? l2_col_index : (l1_col_index ? l1_col_index : spr_col_index);
 			break;
 		case 0:
-			col_index = l2_col_index ?: l1_col_index;
+			col_index = l2_col_index ? l2_col_index : l1_col_index;
 			break;
 	}
 	return col_index;
@@ -656,10 +808,34 @@ render_line(uint16_t y)
 	uint16_t vstart = reg_composer[6] << 1;
 	uint16_t vstop = reg_composer[7] << 1;
 
-	int eff_y = (reg_composer[2] * (y - vstart)) / 128;
-	render_sprite_line(eff_y);
-	render_layer_line(0, eff_y);
-	render_layer_line(1, eff_y);
+	int eff_y = (reg_composer[2] * (y - vstart)) >> 7;
+
+	uint8_t dc_video = reg_composer[0];
+	layer_line_enable[0] = dc_video & 0x10;
+	layer_line_enable[1] = dc_video & 0x20;
+	sprite_line_enable   = dc_video & 0x40;
+
+	if (sprite_line_enable) {
+		render_sprite_line(eff_y);
+	}
+	if (layer_line_enable[0]) {
+		if (layer_properties[0].text_mode) {
+			render_layer_line_text(0, eff_y);
+		} else if (layer_properties[0].bitmap_mode) {
+			render_layer_line_bitmap(0, eff_y);
+		} else {
+			render_layer_line_tile(0, eff_y);
+		}
+	}
+	if (layer_line_enable[1]) {
+		if (layer_properties[1].text_mode) {
+			render_layer_line_text(1, eff_y);
+		} else if (layer_properties[1].bitmap_mode) {
+			render_layer_line_bitmap(1, eff_y);
+		} else {
+			render_layer_line_tile(1, eff_y);
+		}
+	}
 
 	uint8_t col_line[SCREEN_WIDTH];
 
@@ -686,22 +862,22 @@ render_line(uint16_t y)
 
 			int eff_x[LAYER_PIXELS_PER_ITERATION];
 			for (int i = 0; i < LAYER_PIXELS_PER_ITERATION; ++i) {
-				eff_x[i] = (reg_composer[1] * (x + i - hstart)) / 128;
+				eff_x[i] = (reg_composer[1] * (x + i - hstart)) >> 7;
 			}
 
-			if (!sprite_line_empty) {
+			if (sprite_line_enable) {
 				for (int i = 0; i < LAYER_PIXELS_PER_ITERATION; ++i) {
 					spr_col_index[i] = sprite_line_col[eff_x[i]];
 				}
 			}
 
-			if (!layer_line_empty[0]) {
+			if (layer_line_enable[0]) {
 				for (int i = 0; i < LAYER_PIXELS_PER_ITERATION; ++i) {
 					l1_col_index[i] = layer_line[0][eff_x[i]];
 				}
 			}
 
-			if (!layer_line_empty[1]) {
+			if (layer_line_enable[1]) {
 				for (int i = 0; i < LAYER_PIXELS_PER_ITERATION; ++i) {
 					l2_col_index[i] = layer_line[1][eff_x[i]];
 				}
@@ -720,22 +896,22 @@ render_line(uint16_t y)
 				switch (spr_zindex[0]) {
 					case 3:
 						for (int i = 0; i < LAYER_PIXELS_PER_ITERATION; ++i) {
-							col_index[i] = spr_col_index[i] ?: l2_col_index[i] ?: l1_col_index[i];
+							col_index[i] = spr_col_index[i] ? spr_col_index[i] : (l2_col_index[i] ? l2_col_index[i] : l1_col_index[i]);
 						}
 						break;
 					case 2:
 						for (int i = 0; i < LAYER_PIXELS_PER_ITERATION; ++i) {
-							col_index[i] = l2_col_index[i] ?: spr_col_index[i] ?: l1_col_index[i];
+							col_index[i] = l2_col_index[i] ? l2_col_index[i] : (spr_col_index[i] ? spr_col_index[i] : l1_col_index[i]);
 						}
 						break;
 					case 1:
 						for (int i = 0; i < LAYER_PIXELS_PER_ITERATION; ++i) {
-							col_index[i] = l2_col_index[i] ?: l1_col_index[i] ?: spr_col_index[i];
+							col_index[i] = l2_col_index[i] ? l2_col_index[i] : (l1_col_index[i] ? l1_col_index[i] : spr_col_index[i]);
 						}
 						break;
 					case 0:
 						for (int i = 0; i < LAYER_PIXELS_PER_ITERATION; ++i) {
-							col_index[i] = l2_col_index[i] ?: l1_col_index[i];
+							col_index[i] = l2_col_index[i] ? l2_col_index[i] : l1_col_index[i];
 						}
 						break;
 				}
@@ -751,11 +927,17 @@ render_line(uint16_t y)
 		}
 
 		// Add border after if required.
-		if (hstart > 0 || hstop < SCREEN_WIDTH || vstart > 0 || vstop < SCREEN_HEIGHT) {
-			for (uint16_t x = 0; x < SCREEN_WIDTH; x++) {
-				if (x < hstart || x > hstop || y < vstart || y > vstop) {
-					col_line[x] = border_color;
-				}
+		if (y < vstart || y > vstop) {
+			uint32_t border_fill = border_color;
+			border_fill     = border_fill | (border_fill << 8);
+			border_fill     = border_fill | (border_fill << 16);
+			memset(col_line, border_fill, SCREEN_WIDTH);
+		} else {
+			for (uint16_t x = 0; x < hstart; ++x) {
+				col_line[x] = border_color;
+			}
+			for (uint16_t x = hstop; x < SCREEN_WIDTH; ++x) {
+				col_line[x] = border_color;
 			}
 		}
 	}
@@ -804,6 +986,15 @@ video_step(float mhz)
 			render_line(y);
 		}
 		scan_pos_y++;
+		if (scan_pos_y == SCREEN_HEIGHT) {
+			if (ien & 4) {
+				if (sprite_line_collisions != 0) {
+					isr |= 4;
+				}
+				isr = (isr & 0xf) | sprite_line_collisions;
+			}
+			sprite_line_collisions = 0;
+		}
 		if (scan_pos_y == SCAN_HEIGHT) {
 			scan_pos_y = 0;
 			new_frame = true;
@@ -1051,7 +1242,7 @@ uint8_t video_read(uint8_t reg, bool debugOn) {
 			return value;
 		}
 		case 0x05: return (io_dcsel << 1) | io_addrsel;
-		case 0x06: return ((irq_line & 1) << 7) | (ien & 0xF);
+		case 0x06: return ((irq_line & 0x100) >> 1) | (ien & 0xF);
 		case 0x07: return isr | (pcm_is_fifo_almost_empty() ? 8 : 0);
 		case 0x08: return irq_line & 0xFF;
 
@@ -1131,6 +1322,7 @@ void video_write(uint8_t reg, uint8_t value) {
 			isr &= value ^ 0xff;
 			break;
 		case 0x08:
+			irq_line = (irq_line & 0x100) | value;
 			break;
 
 		case 0x09:


### PR DESCRIPTION
This should be a properly reconciled set of changes with my previous PR, tested with ChaseVault, my X16 demos, and the sample sprite collide samples I wrote in https://github.com/indigodarkwolf/x16-samples/tree/master/sprites-collision.