### PR TITLE
Fixing VRAM memory dump

### DIFF
--- a/debugger.c
+++ b/debugger.c
@@ -468,10 +468,9 @@ void DEBUGRenderDisplay(int width, int height) {
 
 	DEBUGRenderRegisters();							// Draw register name and values.
 	DEBUGRenderCode(20, currentPC);							// Render 6502 disassembly.
-	DEBUGRenderData(21, currentData);
-   DEBUGRenderZeroPageRegisters(21);
 	if (dumpmode == DDUMP_RAM) {
 		DEBUGRenderData(21, currentData);
+		DEBUGRenderZeroPageRegisters(21);
 	} else {
 		DEBUGRenderVRAM(21, currentData);
 	}


### PR DESCRIPTION
The merge to add zero-page registers to the debugger caused the system RAM dump to always display, regardless of the new memory dump mode. This fixes the display so system RAM and ZP registers are only displayed in the RAM dumpmode, and not in the VERA dumpmode,