### PR TITLE
Fix VRAM dump in the debugger. Fixes #289

### DIFF
--- a/debugger.c
+++ b/debugger.c
@@ -468,9 +468,8 @@ void DEBUGRenderDisplay(int width, int height) {
 
 	DEBUGRenderRegisters();							// Draw register name and values.
 	DEBUGRenderCode(20, currentPC);							// Render 6502 disassembly.
-	DEBUGRenderData(21, currentData);
-   DEBUGRenderZeroPageRegisters(21);
 	if (dumpmode == DDUMP_RAM) {
+		DEBUGRenderZeroPageRegisters(21);
 		DEBUGRenderData(21, currentData);
 	} else {
 		DEBUGRenderVRAM(21, currentData);


### PR DESCRIPTION
Only render zero page registers when dumpmode is DDUMP_RAM.  Also remove duplicate DEBUGRenderData call that was causing it to always be rendered regardless of dumpmode.