### PR TITLE
Update README to fix debugger op-code change from $FF to $DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ The debugger keys are similar to the Microsoft Debugger shortcut keys, and work 
 |F12|is used to break back into the debugger. This does not happen if you do not have -debug|
 |TAB|when stopped, or single stepping, hides the debug information when pressed 			|
 
-When `-debug` is selected the No-Operation $DB will break into the debugger automatically.
+When `-debug` is selected the STP instruction (opcode $DB) will break into the debugger automatically.
 
 Effectively keyboard routines only work when the debugger is running normally. Single stepping through keyboard code will not work at present.
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ The debugger keys are similar to the Microsoft Debugger shortcut keys, and work 
 |F12|is used to break back into the debugger. This does not happen if you do not have -debug|
 |TAB|when stopped, or single stepping, hides the debug information when pressed 			|
 
-When `-debug` is selected the No-Operation $FF will break into the debugger automatically.
+When `-debug` is selected the No-Operation $DB will break into the debugger automatically.
 
 Effectively keyboard routines only work when the debugger is running normally. Single stepping through keyboard code will not work at present.
 


### PR DESCRIPTION
This updates the README to reflect a change that was made in [81c38c3](https://github.com/commanderx16/x16-emulator/commit/81c38c3c2ffc70ee02e2b0a4316a6eeee4cb323a) to use a different un-used 6502 op-code as the debug breakpoint op-code.