### PR TITLE
Fix compiler errors

### DIFF
--- a/debugger.c
+++ b/debugger.c
@@ -12,6 +12,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <inttypes.h>
 #include <SDL.h>
 #include "glue.h"

--- a/memory.c
+++ b/memory.c
@@ -4,6 +4,7 @@
 
 #include <sys/types.h>
 #include <string.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include "glue.h"
 #include "via.h"

--- a/rendertext.c
+++ b/rendertext.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include <SDL.h>
 #ifdef __MINGW32__
 #include <ctype.h>


### PR DESCRIPTION
This pull request fixes the errors by including stdlib.h in memory.c and including string.h in both debugger.c and rendertext.c.

Tested by running make with the fixes and it ran successfully with no errors.

Here are the aforementioned errors that have been fixed:

"memory.c: In function 'memory_init':
memory.c:27:2: error: implicit declaration of function 'calloc' [-Werror=implici
t-function-declaration]
memory.c:27:8: error: incompatible implicit declaration of built-in function 'ca
lloc' [-Werror]"

"debugger.c: In function 'DEBUGExecCmd':
debugger.c:417:4: error: implicit declaration of function 'strcmp' [-Werror=impl
icit-function-declaration]
debugger.c: In function 'DEBUGAddress':
debugger.c:685:3: error: implicit declaration of function 'strcpy' [-Werror=impl
icit-function-declaration]
debugger.c:685:3: error: incompatible implicit declaration of built-in function
'strcpy' [-Werror]" 

"rendertext.c: In function 'DEBUGInitChars':
rendertext.c:142:2: error: implicit declaration of function 'memset' [-Werror=im
plicit-function-declaration]
rendertext.c:142:2: error: incompatible implicit declaration of built-in functio
n 'memset' [-Werror]"