### PR TITLE
Add `const` to declaration of `mnemonic` in disasm.c

### DIFF
--- a/disasm.c
+++ b/disasm.c
@@ -19,7 +19,7 @@
 
 int disasm(uint16_t pc, uint8_t *RAM, char *line, unsigned int max_line, bool debugOn, uint8_t bank) {
 	uint8_t opcode = real_read6502(pc, debugOn, bank);
-	char *mnemonic = mnemonics[opcode];
+	char const *mnemonic = mnemonics[opcode];
 
 	//
 	//		Test for branches, relative address. These are BRA ($80) and


### PR DESCRIPTION
This fixes [issue 301](https://github.com/commanderx16/x16-emulator/issues/301) by making the `mnemonic` pointer a `const` as well.