### PR TITLE
Add forward declaration for sdcard_attached

### DIFF
--- a/sdcard.h
+++ b/sdcard.h
@@ -8,6 +8,7 @@
 #include <SDL.h>
 
 extern SDL_RWops *sdcard_file;
+extern bool sdcard_attached;
 
 void sdcard_attach();
 void sdcard_detach();


### PR DESCRIPTION
Fixes #303 

This adds a forward declaration to the variable `sdcard_attached` just like there already exists for `sdcard_file`, and therefor fixes the compiler error from issue #303.