### PR TITLE
Fix LOAD/SAVE hypercall so debugger doesn't break

### DIFF
--- a/main.c
+++ b/main.c
@@ -997,6 +997,7 @@ emulator_loop(void *param)
 			}
 			pc = (RAM[0x100 + sp + 1] | (RAM[0x100 + sp + 2] << 8)) + 1;
 			sp += 2;
+			continue;
 		}
 #endif
 


### PR DESCRIPTION
Attempting to step-over or step-into a `jsr $ffd5` resulted in the debugger not having the opportunity to pause execution until after whatever instruction followed the `jsr`.  In the case of the step-over, since the debugger looks for a specific address to pause execution and that address was being processed before the debugger could pause execution, execution would simply continue without the debugger pausing appropriately.

By inserting a "continue" at the end of the hypercall's if-block, the debugger gets it chance to pause execution properly.