### PR TITLE
Send only one mouse update per frame

### DIFF
--- a/ps2.c
+++ b/ps2.c
@@ -205,14 +205,12 @@ void
 mouse_button_down(int num)
 {
 	buttons |= 1 << num;
-	//mouse_send_state();
 }
 
 void
 mouse_button_up(int num)
 {
 	buttons &= (1 << num) ^ 0xff;
-	//mouse_send_state();
 }
 
 void
@@ -220,7 +218,6 @@ mouse_move(int x, int y)
 {
 	mouse_diff_x += x;
 	mouse_diff_y += y;
-	//mouse_send_state();
 }
 
 uint8_t

--- a/ps2.c
+++ b/ps2.c
@@ -205,14 +205,14 @@ void
 mouse_button_down(int num)
 {
 	buttons |= 1 << num;
-	mouse_send_state();
+	//mouse_send_state();
 }
 
 void
 mouse_button_up(int num)
 {
 	buttons &= (1 << num) ^ 0xff;
-	mouse_send_state();
+	//mouse_send_state();
 }
 
 void
@@ -220,7 +220,7 @@ mouse_move(int x, int y)
 {
 	mouse_diff_x += x;
 	mouse_diff_y += y;
-	mouse_send_state();
+	//mouse_send_state();
 }
 
 uint8_t

--- a/ps2.h
+++ b/ps2.h
@@ -27,6 +27,7 @@ void ps2_step(int i);
 void mouse_button_down(int num);
 void mouse_button_up(int num);
 void mouse_move(int x, int y);
+void mouse_send_state();
 uint8_t mouse_read(uint8_t reg);
 
 #endif

--- a/video.c
+++ b/video.c
@@ -1056,6 +1056,8 @@ video_update()
 {
 	static bool cmd_down = false;
 
+	bool mouse_changed = false;
+
 	// if LED is on, stamp red 8x4 square into top right of framebuffer
 	if (led_status) {
 		for (int y = 0; y < 4; y++) {
@@ -1144,9 +1146,11 @@ video_update()
 			switch (event.button.button) {
 				case SDL_BUTTON_LEFT:
 					mouse_button_down(0);
+					mouse_changed = true;
 					break;
 				case SDL_BUTTON_RIGHT:
 					mouse_button_down(1);
+					mouse_changed = true;
 					break;
 			}
 		}
@@ -1154,9 +1158,11 @@ video_update()
 			switch (event.button.button) {
 				case SDL_BUTTON_LEFT:
 					mouse_button_up(0);
+					mouse_changed = true;
 					break;
 				case SDL_BUTTON_RIGHT:
 					mouse_button_up(1);
+					mouse_changed = true;
 					break;
 			}
 		}
@@ -1166,7 +1172,11 @@ video_update()
 			mouse_move(event.motion.x - mouse_x, event.motion.y - mouse_y);
 			mouse_x = event.motion.x;
 			mouse_y = event.motion.y;
+			mouse_changed = true;
 		}
+	}
+	if (mouse_changed) {
+		mouse_send_state();
 	}
 	return true;
 }


### PR DESCRIPTION
ps2.c has been modified to not immediately send changes when mouse_move,
mouse_button_down, and mouse_button up are called. Instead, send_mouse_state
is now accessible from outside ps2.c, and it must be called to send the changes.
This allows us to call the other mouse functions for each mouse update received
from SDL2, which can happen multiple times per frame. Once all of the updates
are processed, send_mouse_state is called, which sends the combined updates
to the emulated system. This prevents the system from receiving too many
updates, which can lead to mouse lag, and therefore fixes #308.