### PR TITLE
Fix VSYNC

### DIFF
--- a/video.c
+++ b/video.c
@@ -1002,7 +1002,8 @@ video_step(float mhz)
 			render_line(y);
 		}
 		scan_pos_y++;
-		if (scan_pos_y == SCREEN_HEIGHT) {
+		y++;
+		if (y == SCREEN_HEIGHT) {
 			if (ien & 4) {
 				if (sprite_line_collisions != 0) {
 					isr |= 4;
@@ -1020,7 +1021,6 @@ video_step(float mhz)
 			frame_count++;
 		}
 		if (ien & 2) { // LINE IRQ
-			y = scan_pos_y - front_porch;
 			if (y < SCREEN_HEIGHT && y == irq_line) {
 				isr |= 2;
 			}

--- a/video.c
+++ b/video.c
@@ -1001,7 +1001,6 @@ video_step(float mhz)
 		if (y < SCREEN_HEIGHT) {
 			render_line(y);
 		}
-		scan_pos_y++;
 		y++;
 		if (y == SCREEN_HEIGHT) {
 			if (ien & 4) {
@@ -1015,6 +1014,7 @@ video_step(float mhz)
 				isr |= 1;
 			}
 		}
+		scan_pos_y++;
 		if (scan_pos_y == SCAN_HEIGHT) {
 			scan_pos_y = 0;
 			new_frame = true;

--- a/video.c
+++ b/video.c
@@ -1010,14 +1010,14 @@ video_step(float mhz)
 				isr = (isr & 0xf) | sprite_line_collisions;
 			}
 			sprite_line_collisions = 0;
+			if (ien & 1) { // VSYNC IRQ
+				isr |= 1;
+			}
 		}
 		if (scan_pos_y == SCAN_HEIGHT) {
 			scan_pos_y = 0;
 			new_frame = true;
 			frame_count++;
-			if (ien & 1) { // VSYNC IRQ
-				isr |= 1;
-			}
 		}
 		if (ien & 2) { // LINE IRQ
 			y = scan_pos_y - front_porch;


### PR DESCRIPTION
The VSYNC interrupt on the Commander X16 should trigger as soon as the current scanline is offscreen. Currently, the interrupt only triggers once the scan returns to the top of the screen, wasting many lines that could otherwise be spent performing time-sensitive operations. This change to video.c causes the interrupt to trigger at the proper location.

This issue was previously discussed here:
https://www.commanderx16.com/forum/index.php?/topic/348-updating-screen-on-vblank-takes-too-long/