### PR TITLE
YM2151 frequency from 4MHz ->3.579545MHz

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -91,8 +91,8 @@ audio_init(const char *dev_name, int num_audio_buffers)
 		exit(-1);
 	}
 
-	// Init YM2151 emulation. 4 MHz clock
-	YM_Create(4000000);
+	// Init YM2151 emulation. 3.579545 MHz clock
+	YM_Create(3579545);
 	YM_init(obtained.freq, 60);
 
 	// Start playback


### PR DESCRIPTION
PR #241 sets the YM frequency to double its intended value, which is improper. This sets the value to 3.579545MHz, which should be the correct value.