### PR TITLE
Reset timing after exiting debugger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,9 @@ ifdef EMSCRIPTEN
 	OUTPUT=x16emu.html
 endif
 
-OBJS = cpu/fake6502.o memory.o disasm.o video.o ps2.o via.o loadsave.o vera_spi.o audio.o vera_pcm.o vera_psg.o sdcard.o main.o debugger.o javascript_interface.o joystick.o rendertext.o keyboard.o icon.o
+OBJS = cpu/fake6502.o memory.o disasm.o video.o ps2.o via.o loadsave.o vera_spi.o audio.o vera_pcm.o vera_psg.o sdcard.o main.o debugger.o javascript_interface.o joystick.o rendertext.o keyboard.o icon.o timing.o
 
-HEADERS = disasm.h cpu/fake6502.h glue.h memory.h video.h audio.h vera_pcm.h vera_psg.h ps2.h via.h loadsave.h joystick.h keyboard.h
+HEADERS = disasm.h cpu/fake6502.h glue.h memory.h video.h audio.h vera_pcm.h vera_psg.h ps2.h via.h loadsave.h joystick.h keyboard.h timing.h
 
 OBJS += extern/src/ym2151.o
 HEADERS += extern/src/ym2151.h

--- a/debugger.c
+++ b/debugger.c
@@ -16,6 +16,7 @@
 #include <inttypes.h>
 #include <SDL.h>
 #include "glue.h"
+#include "timing.h"
 #include "disasm.h"
 #include "memory.h"
 #include "video.h"
@@ -248,6 +249,7 @@ static void DEBUGHandleKeyEvent(SDL_Keycode key,int isShift) {
 			if (opcode == 0x20) { 							// Is it JSR ?
 				stepBreakPoint = pc + 3;					// Then break 3 on.
 				currentMode = DMODE_RUN;					// And run.
+				timing_init();
 			} else {
 				currentMode = DMODE_STEP;					// Otherwise single step.
 			}
@@ -255,6 +257,7 @@ static void DEBUGHandleKeyEvent(SDL_Keycode key,int isShift) {
 
 		case DBGKEY_RUN:									// F5 Runs until Break.
 			currentMode = DMODE_RUN;
+			timing_init();
 			break;
 
 		case DBGKEY_SETBRK:									// F9 Set breakpoint to displayed.

--- a/glue.h
+++ b/glue.h
@@ -52,6 +52,7 @@ extern uint16_t num_ram_banks;
 extern bool debugger_enabled;
 extern bool log_video;
 extern bool log_keyboard;
+extern bool log_speed;
 extern echo_mode_t echo_mode;
 extern bool save_on_exit;
 extern gif_recorder_state_t record_gif;

--- a/main.c
+++ b/main.c
@@ -2,10 +2,6 @@
 // Copyright (c) 2019 Michael Steil
 // All rights reserved. License: 2-clause BSD
 
-#ifndef __APPLE__
-#define _XOPEN_SOURCE   600
-#define _POSIX_C_SOURCE 1
-#endif
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -17,6 +13,7 @@
 #include <ctype.h>
 #endif
 #include "cpu/fake6502.h"
+#include "timing.h"
 #include "disasm.h"
 #include "memory.h"
 #include "video.h"
@@ -85,12 +82,6 @@ char *gif_path = NULL;
 uint8_t keymap = 0; // KERNAL's default
 int window_scale = 1;
 char *scale_quality = "best";
-
-int frames;
-int32_t sdlTicks_base;
-int32_t last_perf_update;
-int32_t perf_frame_count;
-char window_title[30];
 
 #ifdef TRACE
 bool trace_mode = false;
@@ -228,51 +219,6 @@ machine_paste(char *s)
 	if (s) {
 		paste_text = s;
 		pasting_bas = true;
-	}
-}
-
-void
-timing_init() {
-	frames = 0;
-	sdlTicks_base = SDL_GetTicks();
-	last_perf_update = 0;
-	perf_frame_count = 0;
-}
-
-void
-timing_update()
-{
-	frames++;
-	int32_t sdlTicks = SDL_GetTicks() - sdlTicks_base;
-	int32_t diff_time = 1000 * frames / 60 - sdlTicks;
-	if (!warp_mode && diff_time > 0) {
-		usleep(1000 * diff_time);
-	}
-
-	if (sdlTicks - last_perf_update > 5000) {
-		int32_t frameCount = frames - perf_frame_count;
-		int perf = frameCount / 3;
-
-		if (perf < 100 || warp_mode) {
-			sprintf(window_title, "Commander X16 (%d%%)", perf);
-			video_update_title(window_title);
-		} else {
-			video_update_title("Commander X16");
-		}
-
-		perf_frame_count = frames;
-		last_perf_update = sdlTicks;
-	}
-
-	if (log_speed) {
-		float frames_behind = -((float)diff_time / 16.666666);
-		int load = (int)((1 + frames_behind) * 100);
-		printf("Load: %d%%\n", load > 100 ? 100 : load);
-
-		if ((int)frames_behind > 0) {
-			printf("Rendering is behind %d frames.\n", -(int)frames_behind);
-		} else {
-		}
 	}
 }
 

--- a/timing.c
+++ b/timing.c
@@ -1,0 +1,61 @@
+#ifndef __APPLE__
+#define _XOPEN_SOURCE   600
+#define _POSIX_C_SOURCE 1
+#endif
+#include "glue.h"
+#include "video.h"
+#include <SDL.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int frames;
+int32_t sdlTicks_base;
+int32_t last_perf_update;
+int32_t perf_frame_count;
+char window_title[30];
+
+void
+timing_init() {
+	frames = 0;
+	sdlTicks_base = SDL_GetTicks();
+	last_perf_update = 0;
+	perf_frame_count = 0;
+}
+
+void
+timing_update()
+{
+	frames++;
+	int32_t sdlTicks = SDL_GetTicks() - sdlTicks_base;
+	int32_t diff_time = 1000 * frames / 60 - sdlTicks;
+	if (!warp_mode && diff_time > 0) {
+		usleep(1000 * diff_time);
+	}
+
+	if (sdlTicks - last_perf_update > 5000) {
+		int32_t frameCount = frames - perf_frame_count;
+		int perf = frameCount / 3;
+
+		if (perf < 100 || warp_mode) {
+			sprintf(window_title, "Commander X16 (%d%%)", perf);
+			video_update_title(window_title);
+		} else {
+			video_update_title("Commander X16");
+		}
+
+		perf_frame_count = frames;
+		last_perf_update = sdlTicks;
+	}
+
+	if (log_speed) {
+		float frames_behind = -((float)diff_time / 16.666666);
+		int load = (int)((1 + frames_behind) * 100);
+		printf("Load: %d%%\n", load > 100 ? 100 : load);
+
+		if ((int)frames_behind > 0) {
+			printf("Rendering is behind %d frames.\n", -(int)frames_behind);
+		} else {
+		}
+	}
+}
+

--- a/timing.h
+++ b/timing.h
@@ -1,0 +1,7 @@
+#ifndef TIMING_H
+#define TIMING_H
+
+void timing_init();
+void timing_update();
+
+#endif


### PR DESCRIPTION
This pull request causes the emulator to reset its timing when the debugger is exited. This fixes an issue where the emulator would speed up after exiting the debugger. This pull request also moves the timing functions into a new file (with an accompanying header) to allow the timing_init function to be called from the debugger code.