### PR TITLE
YM2151 Clock speed correct for Proto2 Board

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -92,7 +92,7 @@ audio_init(const char *dev_name, int num_audio_buffers)
 	}
 
 	// Init YM2151 emulation. 4 MHz clock
-	YM_Create(4000000);
+	YM_Create(3579545);
 	YM_init(obtained.freq, 60);
 
 	// Start playback

--- a/audio.c
+++ b/audio.c
@@ -91,7 +91,7 @@ audio_init(const char *dev_name, int num_audio_buffers)
 		exit(-1);
 	}
 
-	// Init YM2151 emulation. 4 MHz clock
+	// Init YM2151 emulation. 3.579545MHz clock
 	YM_Create(3579545);
 	YM_init(obtained.freq, 60);
 


### PR DESCRIPTION
There is another pull request which **incorrectly** doubles this frequency.

I have checked this frequency by playing back specific notes and verifying their pitch, and by playing back VGM music and verifying it is now at the correct pitch. I have been working with the YM2151 and various VGM playback routines for a while now, and know exactly how the tunes should sound at this clock rate and what they sounded like (incorrectly) at the previous 4MHz clock speed.

Board 2 will use 3.5MHz clock instead of the 4MHz clock used on the test expansion card that was tested on prototype 1.