### PR TITLE
Remove optional rom_labels.h from HEADERS. Fixed web assembly compile…

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2,6 +2,10 @@
 // Copyright (c) 2019 Michael Steil
 // All rights reserved. License: 2-clause BSD
 
+#ifndef __APPLE__
+#define _XOPEN_SOURCE   600
+#define _POSIX_C_SOURCE 1
+#endif
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>


### PR DESCRIPTION
Two minor tweaks.
I think rom_labels.h is still optional, right ? So I removed it from the HEADERS as it gets included below in the Makefile if it exists.

The second tweak was for WebAssembly compilation which complained about missing MAX_PATH, I brought back included that used to be in main.c up until recently. Not sure if other targets would need that too, i could make that specific __EMSCRIPTEN__ otherwise.