### PR TITLE
Fix: Add support for Delete, Insert, End, PgUp and PgDn keys

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -125,7 +125,7 @@ ps2_scancode_from_SDL_Scancode(SDL_Scancode scancode)
 		case SDL_SCANCODE_Z:
 			return 0x1A;
 		case SDL_SCANCODE_DELETE:
-			return 0;
+			return 0x71 | EXTENDED_FLAG;
 		case SDL_SCANCODE_UP:
 			return 0x75 | EXTENDED_FLAG;
 		case SDL_SCANCODE_DOWN:
@@ -135,15 +135,15 @@ ps2_scancode_from_SDL_Scancode(SDL_Scancode scancode)
 		case SDL_SCANCODE_LEFT:
 			return 0x6b | EXTENDED_FLAG;
 		case SDL_SCANCODE_INSERT:
-			return 0;
+			return 0x70 | EXTENDED_FLAG;
 		case SDL_SCANCODE_HOME:
 			return 0x6c | EXTENDED_FLAG;
 		case SDL_SCANCODE_END:
-			return 0;
+			return 0x69 | EXTENDED_FLAG;
 		case SDL_SCANCODE_PAGEUP:
-			return 0;
+			return 0x7d | EXTENDED_FLAG;
 		case SDL_SCANCODE_PAGEDOWN:
-			return 0;
+			return 0x7a | EXTENDED_FLAG;
 		case SDL_SCANCODE_F1:
 			return 0x05;
 		case SDL_SCANCODE_F2:


### PR DESCRIPTION
This fix adds support for Delete, Insert, End, PgUp and PgDn keys.

This is interesting for two reasons.

A real PS/2 keyboard will send these key codes. The emulator should do the same.

Even though the KERNAL discards the key codes in question, the new feature added to the KERNAL making it possible to create a custom scan code handler may be used to listen for these keys.