### PR TITLE
Fix BRA extra CPU cycle

### DIFF
--- a/src/cpu/65c02.h
+++ b/src/cpu/65c02.h
@@ -61,8 +61,7 @@ static void stz() {
 static void bra() {
     oldpc = pc;
     pc += reladdr;
-    if ((oldpc & 0xFF00) != (pc & 0xFF00)) clockticks6502 += 2; //check if jump crossed a page boundary
-        else clockticks6502++;
+    if ((oldpc & 0xFF00) != (pc & 0xFF00)) clockticks6502++; //check if jump crossed a page boundary
 }
 
 // *******************************************************************************************


### PR DESCRIPTION
I was comparing the CPU cycles my program was using (by checking clockticks6502 on certain IO operations) and noticed that it was taking one more CPU cycle than I was expecting. I looked through the code for the instructions I was calling and found that it's miscounting the cycles required for the `BRA` instruction.

The timing for all the conditional branches is they each take 2 cycles, +1 cycle if the branch is taken, and another +1 if taking the branch crosses a page boundary. `BRA` uses a similar timing, except it always branches, so always takes at least 3 cycles. This is accounted for in `src/cpu/tables.h`, as the `ticktable` entry for `BRA` (`$80`) is `3` ([code](https://github.com/commanderx16/x16-emulator/blob/8852ddd12f2c45e9dea684a253724efc23d9aee6/src/cpu/tables.h#L53)). However, the code for executing the `BRA` instruction works as if it has a base cycle count of `2` ([code](https://github.com/commanderx16/x16-emulator/blob/master/src/cpu/65c02.h#L61)). This results in it getting one more penalty clock cycle than it should have. I'm guessing this mistake was made because the code appears to have been copied from the other branch instructions in `src/cpu/instructions.h`, such as `BEQ` ([code](https://github.com/commanderx16/x16-emulator/blob/master/src/cpu/instructions.h#L99)).