### PR TITLE
Added anti-aliasing to VERA PSG waveforms

### DIFF
--- a/src/vera_psg.c
+++ b/src/vera_psg.c
@@ -22,8 +22,10 @@ struct channel {
 	uint8_t  pw;
 	uint8_t  waveform;
 
-	unsigned phase;
 	uint8_t  noiseval;
+	unsigned phase, inv_freq;
+
+	// uint16_t freq_3;
 };
 
 static struct channel channels[16];
@@ -36,6 +38,15 @@ psg_reset(void)
 	memset(channels, 0, sizeof(channels));
 }
 
+static void
+set_freq(struct channel *ch, const unsigned freq)
+{
+	static const unsigned n = 0x7FFFFFFF;
+	ch->freq = freq;
+	ch->inv_freq = freq ? n / freq : n;
+	// ch->freq_3 = (freq << 1) / 3;
+}
+
 void
 psg_writereg(uint8_t reg, uint8_t val)
 {
@@ -45,8 +56,8 @@ psg_writereg(uint8_t reg, uint8_t val)
 	int idx = reg & 3;
 
 	switch (idx) {
-		case 0: channels[ch].freq = (channels[ch].freq & 0xFF00) | val; break;
-		case 1: channels[ch].freq = (channels[ch].freq & 0x00FF) | (val << 8); break;
+		case 0: set_freq(&channels[ch], (channels[ch].freq & 0xFF00) | val); break;
+		case 1: set_freq(&channels[ch], (channels[ch].freq & 0x00FF) | (val << 8)); break;
 		case 2: {
 			channels[ch].right  = (val & 0x80) != 0;
 			channels[ch].left   = (val & 0x40) != 0;
@@ -60,6 +71,85 @@ psg_writereg(uint8_t reg, uint8_t val)
 		}
 	}
 }
+
+static unsigned
+poly_x(const unsigned phase, const unsigned inv_freq)
+{
+	return ~((phase * inv_freq) >> 16) & 0x7FFF;
+}
+
+static int
+poly_blep(unsigned phase, const unsigned freq, const unsigned inv_freq)
+{
+	const bool dir = phase >= freq;
+	if (dir && (phase ^= 0x1FFFF) >= freq) {
+		return 0;
+	}
+
+	const unsigned x = poly_x(phase, inv_freq);
+	const int y1 = (x * x) >> 25, y2 = -y1;
+
+	return dir ? y1 : y2;
+}
+
+static int
+pulse_blep(const struct channel *ch)
+{
+	const unsigned freq = ch->freq;
+	unsigned phase = ch->phase;
+	const unsigned inv_freq = ch->inv_freq;
+
+	int y = 0;
+
+	for (int i = 0; i < 2; ++ i) {
+		const int x1 = poly_blep(phase, freq, inv_freq), x2 = -x1;
+		y += !i ? x1 : x2;
+
+		if (!i) {
+			phase = (phase + 0x20000 - ((ch->pw + 1) << 10)) & 0x1FFFF;
+		} else {
+			break;
+		}
+	}
+
+	return y;
+}
+
+/* static int
+poly_blamp(unsigned phase, const unsigned freq, const unsigned inv_freq)
+{
+	if (phase >= freq && (phase ^= 0x1FFFF) >= freq) {
+		return 0;
+	}
+
+	const unsigned x = poly_x(phase, inv_freq);
+	const int y = ((x * x) >> 14) * x;
+
+	return y;
+}
+
+static int
+triangle_blamp(const struct channel *ch)
+{
+	const unsigned freq = ch->freq;
+	unsigned phase = ch->phase;
+	const unsigned inv_freq = ch->inv_freq;
+
+	int y = 0;
+
+	for (int i = 0; i < 2; ++i) {
+		const int x1 = poly_blamp(phase, freq, inv_freq), x2 = -x1;
+		y += !i ? x1 : x2;
+
+		if (!i) {
+			phase = (phase + 0x10000) & 0x1FFFF;
+		} else {
+			break;
+		}
+	}
+
+	return ((y >> 16) * ch->freq_3) >> 26;
+} */
 
 static void
 render(int16_t *left, int16_t *right)
@@ -76,19 +166,29 @@ render(int16_t *left, int16_t *right)
 		}
 		ch->phase = new_phase;
 
-		uint8_t v = 0;
+		int v = 0;
 		switch (ch->waveform) {
-			case WF_PULSE: v = (ch->phase >> 10) > ch->pw ? 0 : 63; break;
-			case WF_SAWTOOTH: v = ch->phase >> 11; break;
-			case WF_TRIANGLE: v = (ch->phase & 0x10000) ? (~(ch->phase >> 10) & 0x3F) : ((ch->phase >> 10) & 0x3F); break;
+			case WF_PULSE: {
+				v = (ch->phase >> 10) > ch->pw ? 0 : 63;
+				v += pulse_blep(ch);
+				break;
+			}
+			case WF_SAWTOOTH: {
+				v = ch->phase >> 11;
+				v -= poly_blep(ch->phase, ch->freq, ch->inv_freq);
+				break;
+			}
+			case WF_TRIANGLE: {
+				v = (ch->phase & 0x10000) ? (~(ch->phase >> 10) & 0x3F) : ((ch->phase >> 10) & 0x3F);
+				// aliasing in triangle is already barely audible, so don't bother
+				// v += triangle_blamp(ch);
+				break;
+			}
 			case WF_NOISE: v = ch->noiseval; break;
 		}
-		int8_t sv = (v ^ 0x20);
-		if (sv & 0x20) {
-			sv |= 0xC0;
-		}
+		v -= 32;
 
-		int val = (int)sv * (int)ch->volume;
+		int val = v * (int)ch->volume;
 
 		if (ch->left) {
 			l += val;


### PR DESCRIPTION
This adds anti-aliasing using polyBLEPs to the pulse/sawtooth waveforms. It also includes anti-aliasing for the triangle waveform, but this is disabled, because it's good enough as it is (IMHO, YMMV).

This will obviously be slower than without anti-aliasing (so maybe it should be optional?), but performance should still be pretty good.

It should probably be tested some more, because although it seems to work fine in isolation, I haven't yet tested it in the actually emulator itself...

BTW, I assume the actual VERA PSG hardware doesn't suffer from aliasing, right?