### PR TITLE
assures base_path is a valid pointer

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -449,6 +449,8 @@ main(int argc, char **argv)
 	run_after_load = false;
 
 	char *base_path = SDL_GetBasePath();
+	if (!base_path)
+		base_path = SDL_strdup("./");
 
 	// This causes the emulator to load ROM data from the executable's directory when
 	// no ROM file is specified on the command line.


### PR DESCRIPTION
SDL_GetBasePath returns NULL on OpenBSD 6.9. This allows the program to build and run without issue on the platform.

It ain't much, but it's honest work.