### PR TITLE
Work around format overflow error with GCC 11

### DIFF
--- a/src/debugger.c
+++ b/src/debugger.c
@@ -512,7 +512,7 @@ static void DEBUGRenderCmdLine(int x, int width, int height) {
 
 static void DEBUGRenderZeroPageRegisters(int y) {
 #define LAST_R 15
-	int reg = 0;
+	unsigned char reg = 0;
 	int y_start = y;
 	char lbl[6];
 	while (reg < DBGMAX_ZERO_PAGE_REGISTERS) {


### PR DESCRIPTION
Fixes #361 