### PR TITLE
fix r39 version tag

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -2,6 +2,6 @@
 // Copyright (c) 2019, 2020 Michael Steil
 // All rights reserved. License: 2-clause BSD
 
-#define VER "38"
-#define VER_NAME "Kyoto"
-#define VER_INFO "### Release 38 (\"Kyoto\")\n"
+#define VER "39"
+#define VER_NAME "Buenos Aires"
+#define VER_INFO "### Release 39 (\"Buenos Aires\")\n"


### PR DESCRIPTION
The emulator still prints releas 38 Kyoto, this change fixes that to 39 Buenos Aires.