### PR TITLE
add missing cli args to readme and add missing word

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ You can start `x16emu`/`x16emu.exe` either by double-clicking it, or from the co
 
 * When starting `x16emu` without arguments, it will pick up the system ROM (`rom.bin`) from the executable's directory.
 * The system ROM filename/path can be overridden with the `-rom` command line argument.
+* `-ram <ramsize>` specifies banked RAM size in KB (8, 16, 32, ..., 2048). The default is 512.
 * `-nvram` lets you specify a 64 byte file for the system's non-volatile RAM. If it does not exist, it will be created once the NVRAM is modified.
 * `-keymap` tells the KERNAL to switch to a specific keyboard layout. Use it without an argument to view the supported layouts.
 * `-sdcard` lets you specify an SD card image (partition table + FAT32).
@@ -99,7 +100,7 @@ You can start `x16emu`/`x16emu.exe` either by double-clicking it, or from the co
 * `-run` executes the application specified through `-prg` or `-bas` using `RUN` or `SYS`, depending on the load address.
 * `-geos` launches GEOS at startup.
 * `-scale` scales video output to an integer multiple of 640x480
-* `-echo` causes all KERNAL/BASIC output to be printed to the host's terminal. Enable this and use the BASIC command "LIST" to convert a BASIC program to ASCII (detokenize).
+* `-echo [{iso|raw}]` causes all KERNAL/BASIC output to be printed to the host's terminal. Enable this and use the BASIC command "LIST" to convert a BASIC program to ASCII (detokenize).
 * `-warp` causes the emulator to run as fast as possible, possibly faster than a real X16.
 * `-gif <filename>[,wait]` to record the screen into a GIF. See below for more info.
 * `-quality` change image scaling algorithm quality
@@ -116,9 +117,11 @@ You can start `x16emu`/`x16emu.exe` either by double-clicking it, or from the co
 	* `R`: RAM (40 KiB)
 	* `B`: Banked RAM (2 MiB)
 	* `V`: Video RAM and registers (128 KiB VRAM, 32 B composer registers, 512 B palette, 16 B layer0 registers, 16 B layer1 registers, 16 B sprite registers, 2 KiB sprite attributes)
+* `-joy1` , `-joy2`, `-joy3`, `-joy4` enables binding a gamepad to that SNES controller port
 * `-sound` can be used to specify the output sound device.
 * `-abufs` can be used to specify the number of audio buffers (defaults to 8). If you're experiencing stuttering in the audio try to increase this number. This will result in additional audio latency though.
 * `-rtc` causes the real-time-clock set to the system's time and date.
+* `-version` prints additional version information of the emulator and ROM.
 * When compiled with `#define TRACE`, `-trace` will enable an instruction trace on stdout.
 
 Run `x16emu -h` to see all command line options.

--- a/src/main.c
+++ b/src/main.c
@@ -415,7 +415,7 @@ usage()
 	printf("\tcan be specified.\n");
 #endif
 	printf("-version\n");
-	printf("\tPrint additional version information the emulator and ROM.\n");
+	printf("\tPrint additional version information of the emulator and ROM.\n");
 	printf("\n");
 	exit(1);
 }


### PR DESCRIPTION
A few command line arguments were missing in the readme.

I noticed that the readme is less specific about the cli args than the emulator's help output itself, should we improve it in that regard?
