### PR TITLE
Add emulator-specific register for disabling consumption of Ctrl/Cmd keys

### DIFF
--- a/src/glue.h
+++ b/src/glue.h
@@ -56,6 +56,7 @@ extern bool log_keyboard;
 extern bool log_speed;
 extern echo_mode_t echo_mode;
 extern bool save_on_exit;
+extern bool disable_emu_cmd_keys;
 extern gif_recorder_state_t record_gif;
 extern char *gif_path;
 extern uint8_t keymap;

--- a/src/main.c
+++ b/src/main.c
@@ -84,6 +84,7 @@ bool dump_vram = false;
 bool warp_mode = false;
 echo_mode_t echo_mode;
 bool save_on_exit = true;
+bool disable_emu_cmd_keys = false;
 bool set_system_time = false;
 bool has_serial = false;
 gif_recorder_state_t record_gif = RECORD_GIF_DISABLED;

--- a/src/memory.c
+++ b/src/memory.c
@@ -255,6 +255,8 @@ emu_read(uint8_t reg, bool debugOn)
 		return save_on_exit ? 1 : 0;
 	} else if (reg == 5) {
 		return record_gif;
+	} else if (reg == 6) {
+		return disable_emu_cmd_keys ? 1 : 0;
 
 	} else if (reg == 8) {
 		return (clockticks6502 >> 0) & 0xff;

--- a/src/memory.c
+++ b/src/memory.c
@@ -235,6 +235,7 @@ emu_write(uint8_t reg, uint8_t value)
 		case 3: echo_mode = value; break;
 		case 4: save_on_exit = v; break;
 		case 5: emu_recorder_set((gif_recorder_command_t) value); break;
+		case 6: disable_emu_cmd_keys = v; break;
 		default: printf("WARN: Invalid register %x\n", DEVICE_EMULATOR + reg);
 	}
 }

--- a/src/video.c
+++ b/src/video.c
@@ -1129,7 +1129,7 @@ video_update()
 				}
 			}
 			if (!consumed) {
-				if (event.key.keysym.scancode == LSHORTCUT_KEY || event.key.keysym.scancode == RSHORTCUT_KEY) {
+				if (!disable_emu_cmd_keys && (event.key.keysym.scancode == LSHORTCUT_KEY || event.key.keysym.scancode == RSHORTCUT_KEY)) {
 					cmd_down = true;
 				}
 				handle_keyboard(true, event.key.keysym.sym, event.key.keysym.scancode);


### PR DESCRIPTION
While writing an application to take full advantage of PS/2 scancodes, I would like to be able to process keystrokes like Ctrl+A and Ctrl+V without the emulator unconditionally intercepting them.

Added the ability to poke a true value into $9FB6 to disable the emulator's behavior of capturing of these keystrokes.