### PR TITLE
Moving register used for disabling emulator ctrl keybinds due to a conflict with the implementation of register 6 in Box16 emulator

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -235,7 +235,8 @@ emu_write(uint8_t reg, uint8_t value)
 		case 3: echo_mode = value; break;
 		case 4: save_on_exit = v; break;
 		case 5: emu_recorder_set((gif_recorder_command_t) value); break;
-		case 6: disable_emu_cmd_keys = v; break;
+		// 6 is used by Box16 for recording wav output
+		case 7: disable_emu_cmd_keys = v; break;
 		default: printf("WARN: Invalid register %x\n", DEVICE_EMULATOR + reg);
 	}
 }
@@ -255,7 +256,8 @@ emu_read(uint8_t reg, bool debugOn)
 		return save_on_exit ? 1 : 0;
 	} else if (reg == 5) {
 		return record_gif;
-	} else if (reg == 6) {
+	// 6 is used by Box16 for recording wav output
+	} else if (reg == 7) {
 		return disable_emu_cmd_keys ? 1 : 0;
 
 	} else if (reg == 8) {


### PR DESCRIPTION
After discussing with @indigodarkwolf I'm hoping we can move this functionality from $9FB6 to $9FB7.