### PR TITLE
Use current RAM/ROM bank for PC when entering break.

### DIFF
--- a/src/debugger.c
+++ b/src/debugger.c
@@ -227,6 +227,7 @@ void DEBUGSetBreakPoint(int newBreakPoint) {
 void DEBUGBreakToDebugger(void) {
 	currentMode = DMODE_STOP;
 	currentPC = pc;
+   currentPCBank = pc < 0xC000 ? memory_get_ram_bank() : memory_get_rom_bank();
 }
 
 // *******************************************************************************************


### PR DESCRIPTION
Focused PR to address Issue #318, "Debugger not using proper bank in disasm"