### PR TITLE
remove unused duplicate symbol that causes compilation error

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -127,8 +127,6 @@ bool prg_finished_loading;
 int prg_override_start = -1;
 bool run_after_load = false;
 
-bool test = true;
-
 char *nvram_path = NULL;
 
 #ifdef TRACE


### PR DESCRIPTION
This is a simple PR that only removes the unused double defined 'test' symbol in main.c, which fixes compilation errors on certain compilers.
fixes #412 and #417