### PR TITLE
Add a `-widescreen` option for stretching the output to 16:9

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -111,6 +111,7 @@ char *gif_path = NULL;
 char *wav_path = NULL;
 uint8_t keymap = 0; // KERNAL's default
 int window_scale = 1;
+double screen_x_scale = 1.0;
 char *scale_quality = "best";
 bool test_init_complete=false;
 bool headless = false;
@@ -449,6 +450,8 @@ usage()
 	printf("\tScale output to an integer multiple of 640x480\n");
 	printf("-quality {nearest|linear|best}\n");
 	printf("\tScaling algorithm quality\n");
+	printf("-widescreen\n");
+	printf("\tStretch output to 16:9 resolution to mimic display of a widescreen monitor.\n");
 	printf("-debug [<address>]\n");
 	printf("\tEnable debugger. Optionally, set a breakpoint\n");
 	printf("-dump {C|R|B|V}...\n");
@@ -798,6 +801,10 @@ main(int argc, char **argv)
 			}
 			argc--;
 			argv++;
+		} else if (!strcmp(argv[0], "-widescreen")) {
+			argc--;
+			argv++;
+			screen_x_scale = 1.333;
 		} else if (!strcmp(argv[0], "-sound")) {
 			argc--;
 			argv++;
@@ -922,7 +929,7 @@ main(int argc, char **argv)
 	if (!headless) {
 		SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER | SDL_INIT_AUDIO);
 		audio_init(audio_dev_name, audio_buffers);
-		video_init(window_scale, scale_quality);
+		video_init(window_scale, screen_x_scale, scale_quality);
 	}
 
 	wav_recorder_set_path(wav_path);

--- a/src/video.c
+++ b/src/video.c
@@ -175,7 +175,7 @@ video_reset()
 }
 
 bool
-video_init(int window_scale, char *quality)
+video_init(int window_scale, double screen_x_scale, char *quality)
 {
 	uint32_t window_flags = SDL_WINDOW_ALLOW_HIGHDPI;
 
@@ -187,11 +187,11 @@ video_init(int window_scale, char *quality)
 	video_reset();
 
 	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, quality);
-	SDL_CreateWindowAndRenderer(SCREEN_WIDTH * window_scale, SCREEN_HEIGHT * window_scale, window_flags, &window, &renderer);
+	SDL_CreateWindowAndRenderer(SCREEN_WIDTH * window_scale * screen_x_scale, SCREEN_HEIGHT * window_scale, window_flags, &window, &renderer);
 #ifndef __MORPHOS__
 	SDL_SetWindowResizable(window, true);
 #endif
-	SDL_RenderSetLogicalSize(renderer, SCREEN_WIDTH, SCREEN_HEIGHT);
+	SDL_RenderSetLogicalSize(renderer, SCREEN_WIDTH * screen_x_scale, SCREEN_HEIGHT);
 
 	sdlTexture = SDL_CreateTexture(renderer,
 									SDL_PIXELFORMAT_RGB888,

--- a/src/video.h
+++ b/src/video.h
@@ -11,7 +11,7 @@
 #include <SDL.h>
 #include "glue.h"
 
-bool video_init(int window_scale, char *quality);
+bool video_init(int window_scale, double screen_x_scale,  char *quality);
 void video_reset(void);
 bool video_step(float mhz, float steps);
 bool video_update(void);


### PR DESCRIPTION
I realized after watching the X16 demo'd at VCF Midwest that a lot of users are going to hook them up to 16:9 monitors rather than 4:3, and not all of these monitors will have the option to render the image at 4:3.  The sad reality is that we should probably expect the average Commander X16 user to view the output in 16:9 rather than the intended 4:3.

With that in mind, I thought that the emulator should have an option for displaying the output in the way that users are most likely going to be viewing it.  This will be useful for application/game developers to view their projects as they will realistically be seen by the users.