### PR TITLE
Handle SDL_GetBasePath() returning null.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -515,10 +515,15 @@ main(int argc, char **argv)
 
 	char *base_path = SDL_GetBasePath();
 
+    if (!base_path) {
+        base_path = SDL_strdup("./");
+    }
+
 	// This causes the emulator to load ROM data from the executable's directory when
 	// no ROM file is specified on the command line.
 	memcpy(rom_path, base_path, strlen(base_path) + 1);
 	strncpy(rom_path + strlen(rom_path), rom_filename, PATH_MAX - strlen(rom_path));
+    SDL_free(base_path);
 
 	argc--;
 	argv++;


### PR DESCRIPTION
SDL_GetBasePath() returns null on systems that don't implement it.

Set to "./" per SDL docs example.

My OS (apparently) doesn't implement SDL_GetBasePath() and the emulator was crashing on startup.

Note: I haven't tested this on Windows, I don't have a way to do so. I don't know whether Windows gets upset about "./".