### PR TITLE
Add PCM_CTRL bit6 FIFO_EMPTY status flag.

### DIFF
--- a/src/vera_pcm.c
+++ b/src/vera_pcm.c
@@ -54,6 +54,9 @@ pcm_read_ctrl(void)
 	if (fifo_cnt == sizeof(fifo)) {
 		result |= 0x80;
 	}
+	if (fifo_cnt == 0) {
+		result |= 0x40;
+	}
 	return result;
 }
 


### PR DESCRIPTION
VERA master repo recently added this functionality. This is the emulator implementation of that feature.