### PR TITLE
Host FS MACPTR behavior for fast VLOAD

### DIFF
--- a/src/ieee.c
+++ b/src/ieee.c
@@ -482,7 +482,7 @@ TALK(uint8_t a)
 }
 
 int
-MACPTR(uint16_t addr, uint16_t *c)
+MACPTR(uint16_t addr, uint16_t *c, uint8_t stream_mode)
 {
 	int ret = -1;
 	int count = *c ?: 256;
@@ -492,12 +492,14 @@ MACPTR(uint16_t addr, uint16_t *c)
 		uint8_t byte = 0;
 		ret = ACPTR(&byte);
 		write6502(addr, byte);
-		addr++;
 		i++;
-		if (addr == 0xc000) {
-			addr = 0xa000;
-			ram_bank++;
-			write6502(0, ram_bank);
+		if (!stream_mode) {
+			addr++;
+			if (addr == 0xc000) {
+				addr = 0xa000;
+				ram_bank++;
+				write6502(0, ram_bank);
+			}
 		}
 		if (ret >= 0) {
 			break;

--- a/src/ieee.h
+++ b/src/ieee.h
@@ -11,4 +11,4 @@ void UNTLK(void);
 int UNLSN(void);
 void LISTEN(uint8_t a);
 void TALK(uint8_t a);
-int MACPTR(uint16_t addr, uint16_t *count);
+int MACPTR(uint16_t addr, uint16_t *count, uint8_t stream_mode);

--- a/src/main.c
+++ b/src/main.c
@@ -1062,7 +1062,7 @@ handle_ieee_intercept()
 	switch(pc) {
 		case 0xFF44: {
 			uint16_t count = a;
-			s=MACPTR(y << 8 | x, &count);
+			s=MACPTR(y << 8 | x, &count, status & 0x01);
 			x = count & 0xff;
 			y = count >> 8;
 			status &= 0xfe; // clear C -> supported


### PR DESCRIPTION
Pending Kernal PR#337 modifies the behavior of MACPTR by adding an argument to the API:
C set = use "stream mode" (do not advance the dst pointer during copy from buffer)
C clear = normal mode

The HostFS implementation needs to match this or else programs break, since the Kernal LOAD routine uses this argument.