### PR TITLE
Clear D Flag on IRQ/NMI

### DIFF
--- a/src/cpu/fake6502.c
+++ b/src/cpu/fake6502.c
@@ -171,8 +171,9 @@ static void putvalue(uint16_t saveval) {
 
 void nmi6502() {
     push16(pc);
-    push8(status);
-    status |= FLAG_INTERRUPT;
+    push8(status & ~FLAG_BREAK);
+    setinterrupt();
+    cleardecimal();
     pc = (uint16_t)read6502(0xFFFA) | ((uint16_t)read6502(0xFFFB) << 8);
     waiting = 0;
 }
@@ -181,7 +182,8 @@ void irq6502() {
     if (!(status & FLAG_INTERRUPT)) {
         push16(pc);
         push8(status & ~FLAG_BREAK);
-        status |= FLAG_INTERRUPT;
+        setinterrupt();
+        cleardecimal();
         pc = (uint16_t)read6502(0xFFFE) | ((uint16_t)read6502(0xFFFF) << 8);
     }
     waiting = 0;

--- a/src/cpu/support.h
+++ b/src/cpu/support.h
@@ -71,7 +71,9 @@ void reset6502() {
     x = 0;
     y = 0;
     sp = 0xFD;
-    status |= FLAG_CONSTANT;
-	waiting = 0;
+    status |= FLAG_CONSTANT | FLAG_BREAK;
+    setinterrupt();
+    cleardecimal();
+    waiting = 0;
 }
 


### PR DESCRIPTION
This is an attempt to fix #414

The code was already clearing the decimal flag on a `BRK` instruction, so this changes it to also clear it on IRQ, NMI, and RESET signals. I also improved the handling of other flags during these signals. According to [section 3.11 of the manual](https://www.westerndesigncenter.com/wdc/documentation/w65c02s.pdf), the B and I flags are set during a reset, so this PR also sets those flags during a reset. With that change to how the B flag is handled, I also updated the NMI to push the status register with the B flag cleared. I had some difficulty determining how the flag is handled on an NMI, with the only resource I could find being [this one for the NES](https://www.nesdev.org/wiki/Status_flags#The_B_flag), so I'm not 100% confident about how it's handled on the 65C02.