### PR TITLE
Debugging improvements

### DIFF
--- a/src/i2c.c
+++ b/src/i2c.c
@@ -280,7 +280,6 @@ mouse_send(int x, int y, int b)
 
 		return true;
 	} else {
-		printf("buffer full, skipping...\n");
 		return false;
 	}
 }

--- a/src/main.c
+++ b/src/main.c
@@ -453,6 +453,8 @@ usage()
 	printf("\tStretch output to 16:9 resolution to mimic display of a widescreen monitor.\n");
 	printf("-debug [<address>]\n");
 	printf("\tEnable debugger. Optionally, set a breakpoint\n");
+	printf("-wuninit\n");
+	printf("\tPrints warning to stdout if uninitialized RAM is accessed\n");
 	printf("-dump {C|R|B|V}...\n");
 	printf("\tConfigure system dump: (C)PU, (R)AM, (B)anked-RAM, (V)RAM\n");
 	printf("\tMultiple characters are possible, e.g. -dump CV ; Default: RB\n");
@@ -729,6 +731,10 @@ main(int argc, char **argv)
 				argc--;
 				argv++;
 			}
+		} else if (!strcmp(argv[0], "-wuninit")) {
+			argc--;
+			argv++;
+			memory_report_uninitialized_access(true);
 		} else if (!strcmp(argv[0], "-joy1")) {
 			argc--;
 			argv++;

--- a/src/main.c
+++ b/src/main.c
@@ -453,6 +453,8 @@ usage()
 	printf("\tStretch output to 16:9 resolution to mimic display of a widescreen monitor.\n");
 	printf("-debug [<address>]\n");
 	printf("\tEnable debugger. Optionally, set a breakpoint\n");
+	printf("-randram\n");
+	printf("\tSet all RAM to random values\n");
 	printf("-wuninit\n");
 	printf("\tPrints warning to stdout if uninitialized RAM is accessed\n");
 	printf("-dump {C|R|B|V}...\n");
@@ -731,6 +733,10 @@ main(int argc, char **argv)
 				argc--;
 				argv++;
 			}
+		} else if (!strcmp(argv[0], "-randram")) {
+			argc--;
+			argv++;
+			memory_randomize_ram(true);
 		} else if (!strcmp(argv[0], "-wuninit")) {
 			argc--;
 			argv++;

--- a/src/memory.h
+++ b/src/memory.h
@@ -17,6 +17,7 @@ void write6502(uint16_t address, uint8_t value);
 void memory_init();
 void memory_reset();
 void memory_report_uninitialized_access(bool);
+void memory_randomize_ram(bool);
 
 void memory_save(SDL_RWops *f, bool dump_ram, bool dump_bank);
 

--- a/src/memory.h
+++ b/src/memory.h
@@ -16,6 +16,7 @@ void write6502(uint16_t address, uint8_t value);
 
 void memory_init();
 void memory_reset();
+void memory_report_uninitialized_access(bool);
 
 void memory_save(SDL_RWops *f, bool dump_ram, bool dump_bank);
 


### PR DESCRIPTION
This PR is to improve debugging in two ways that are somewhat linked to each other.

Currently, all RAM is initialized to zero in the emulator. This is not the case on real hardware, where you must not rely on the values of uninitialized RAM.

From experience, it's easy to write code by mistake that needs some part of RAM being initialized to zero when you use the current emulator.

To make this kind of bug easier to find, I propose the following changes:

- All RAM is initialized to random values on startup, as it would be on hardware
- The option "-wuninit" is added to the emulator; the emulator keeps record of which RAM addresses have been written to, and a warning is printed to stdout if code reads from uninitialized RAM.