### PR TITLE
Build Emulator in CI for Windows, Linux and Mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,14 +13,26 @@ jobs:
         with:
           msystem: MINGW64
           update: true
-          install: git make mingw-w64-x86_64-toolchain mingw-w64-x86_64-libelf mingw-w64-x86_64-SDL2
+          install: make mingw-w64-x86_64-toolchain mingw-w64-x86_64-libelf mingw-w64-x86_64-SDL2
       - name: Build Emulator
         run: |
           CROSS_COMPILE_WINDOWS=1 SDL2CONFIG=sdl2-config make V=1 -j4
           mkdir emu_binaries
           cp $(which SDL2.dll) emu_binaries/.
           cp x16emu.exe emu_binaries/.
-          file emu_binaries/bin/*
+          file emu_binaries/*
+      - name: Download latest ROM
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          repo: ${{ github.repository }}
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          workflow_conclusion: success
+          path: latest_rom
+      - name: Copy ROM
+        run: |
+          ls -lR .
+          cp latest_rom/rom.bin emu_binaries/.
       - uses: actions/upload-artifact@v3
         with:
           name: Windows 64-bit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
@@ -40,7 +40,7 @@ jobs:
   build-lin64:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Dependencies
         run: sudo apt-get install -y build-essential make libsdl2-dev
       - name: Build Emulator
@@ -70,7 +70,7 @@ jobs:
     # this is currently macos-11, Big Sur
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Dependencies
         run: | 
           brew install make sdl2 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,13 +22,11 @@ jobs:
           cp x16emu.exe emu_binaries/.
           file emu_binaries/*
       - name: Download latest ROM
-        id: download-artifact
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          repo: maxgerhardt/x16-rom
-          github_token: ${{secrets.GITHUB_TOKEN}}
-          workflow_conclusion: success
-          path: latest_rom
+        id: download
+        run: |
+          gh run download --name maxgerhardt/x16-rom --dir ${{env.working-directory}}/latest_rom
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Copy ROM
         run: |
           ls -lR .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,40 @@ jobs:
         run: |
           cp latest_rom/rom.bin emu_binaries/.
           cp latest_rom/*.sym emu_binaries/.
+      - name: Tar files
+        run: tar -cvf x16emu.tar.gz -C emu_binaries .
       - uses: actions/upload-artifact@v3
         with:
           name: X16-Emu Linux 64-bit
-          path: emu_binaries/*
+          path: x16emu.tar.gz
+  build-darwin-x64:
+    # this is currently macos-11, Big Sur
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependenncies
+        run: | 
+          brew install make sdl2 
+      - name: Build Emulator
+        run: |
+          MAC_STATIC=1 make V=1 -j3
+          mkdir emu_binaries
+          cp sdcard.img.zip emu_binaries/.
+          cp x16emu emu_binaries/.
+          file emu_binaries/*
+      - name: Download latest ROM
+        id: download
+        run: |
+          gh run download -R maxgerhardt/x16-rom -n "ROM Image" --dir latest_rom
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Copy ROM
+        run: |
+          cp latest_rom/rom.bin emu_binaries/.
+          cp latest_rom/*.sym emu_binaries/.
+      - name: Tar files
+        run: tar -cvf x16emu.tar.gz -C emu_binaries .
+      - uses: actions/upload-artifact@v3
+        with:
+          name: X16-Emu Mac Intel 64-bit
+          path: x16emu.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
           install: make mingw-w64-x86_64-toolchain mingw-w64-x86_64-libelf mingw-w64-x86_64-SDL2
       - name: Build Emulator
         run: |
-          CROSS_COMPILE_WINDOWS=1 SDL2CONFIG=sdl2-config make V=1 -j4
+          CROSS_COMPILE_WINDOWS=1 SDL2CONFIG=sdl2-config make V=1 -j2
           mkdir emu_binaries
           cp $(which SDL2.dll) emu_binaries/.
           cp sdcard.img.zip emu_binaries/.
@@ -36,4 +36,32 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: X16-Emu Windows 64-bit
+          path: emu_binaries/*
+  build-lin64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependenncies
+        run: sudo apt-get install -y build-essential make libsdl2-dev
+      - name: Build Emulator
+        run: |
+          make V=1 -j3
+          mkdir emu_binaries
+          cp $(which SDL2.dll) emu_binaries/.
+          cp sdcard.img.zip emu_binaries/.
+          cp x16emu emu_binaries/.
+          file emu_binaries/*
+      - name: Download latest ROM
+        id: download
+        run: |
+          gh run download -R maxgerhardt/x16-rom -n "ROM Image" --dir latest_rom
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Copy ROM
+        run: |
+          cp latest_rom/rom.bin emu_binaries/.
+          cp latest_rom/*.sym emu_binaries/.
+      - uses: actions/upload-artifact@v3
+        with:
+          name: X16-Emu Linux 64-bit
           path: emu_binaries/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build Binaries
+on: [push, pull_request]
+
+jobs:
+  build-win64:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: git make mingw-w64-x86_64-toolchain mingw-w64-x86_64-libelf mingw-w64-x86_64-SDL2
+      - name: Build Emulator
+        run: |
+          CROSS_COMPILE_WINDOWS=1 SDL2CONFIG=sdl2-config make V=1 -j4
+          mkdir emu_binaries
+          cp $(which SDL2.dll) emu_binaries/.
+          cp x16emu.exe emu_binaries/.
+          file emu_binaries/bin/*
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Windows 64-bit
+          path: emu_binaries/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,6 @@ jobs:
         run: |
           make V=1 -j3
           mkdir emu_binaries
-          cp $(which SDL2.dll) emu_binaries/.
           cp sdcard.img.zip emu_binaries/.
           cp x16emu emu_binaries/.
           file emu_binaries/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         id: download-artifact
         uses: dawidd6/action-download-artifact@v2
         with:
-          repo: https://github.com/maxgerhardt/x16-rom/
+          repo: maxgerhardt/x16-rom
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow_conclusion: success
           path: latest_rom

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,9 +76,6 @@ jobs:
           brew install make sdl2 
       - name: Build Emulator
         run: |
-          ls -l /usr/local/Cellar/
-          ls -lR /usr/local/Cellar/sdl2 || true
-          which libSDL2.a || true
           MAC_STATIC=1 LIBSDL_FILE=/usr/local/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
           ls -l /usr/local/Cellar/
           ls -lR /usr/local/Cellar/sdl2 || true
           which libSDL2.a || true
-          MAC_STATIC=1 make V=1 -j3
+          MAC_STATIC=1 LIBSDL_FILE=/usr/local/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.
           cp x16emu emu_binaries/.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,17 +26,14 @@ jobs:
         id: download
         run: |
           gh run download -R maxgerhardt/x16-rom -n "ROM Image" --dir latest_rom
-          pwd
-          tree
         shell: cmd
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Copy ROM
         run: |
-          ls -lR .
           cp latest_rom/rom.bin emu_binaries/.
           cp latest_rom/*.sym emu_binaries/.
       - uses: actions/upload-artifact@v3
         with:
-          name: X16-Emu (${GITHUB_SHA::7}) Windows 64-bit
+          name: X16-Emu Windows 64-bit
           path: emu_binaries/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,12 +19,15 @@ jobs:
           CROSS_COMPILE_WINDOWS=1 SDL2CONFIG=sdl2-config make V=1 -j4
           mkdir emu_binaries
           cp $(which SDL2.dll) emu_binaries/.
+          cp sdcard.img.zip emu_binaries/.
           cp x16emu.exe emu_binaries/.
           file emu_binaries/*
       - name: Download latest ROM
         id: download
         run: |
-          gh run download -R maxgerhardt/x16-rom -n "ROM Image" --dir ${{env.working-directory}}/latest_rom
+          gh run download -R maxgerhardt/x16-rom -n "ROM Image" --dir latest_rom
+          pwd
+          tree
         shell: cmd
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -32,6 +35,7 @@ jobs:
         run: |
           ls -lR .
           cp latest_rom/rom.bin emu_binaries/.
+          cp latest_rom/*.sym emu_binaries/.
       - uses: actions/upload-artifact@v3
         with:
           name: X16-Emu (${GITHUB_SHA::7}) Windows 64-bit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
         id: download
         run: |
           gh run download --name maxgerhardt/x16-rom --dir ${{env.working-directory}}/latest_rom
+        shell: cmd
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Copy ROM

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         id: download-artifact
         uses: dawidd6/action-download-artifact@v2
         with:
-          repo: ${{ github.repository }}
+          repo: https://github.com/maxgerhardt/x16-rom/
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow_conclusion: success
           path: latest_rom

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Download latest ROM
         id: download
         run: |
-          gh run download --name maxgerhardt/x16-rom --dir ${{env.working-directory}}/latest_rom
+          gh run download -R maxgerhardt/x16-rom -n "ROM Image" --dir ${{env.working-directory}}/latest_rom
         shell: cmd
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -34,5 +34,5 @@ jobs:
           cp latest_rom/rom.bin emu_binaries/.
       - uses: actions/upload-artifact@v3
         with:
-          name: Windows 64-bit
+          name: X16-Emu (${GITHUB_SHA::7}) Windows 64-bit
           path: emu_binaries/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Dependenncies
+      - name: Install Dependencies
         run: sudo apt-get install -y build-essential make libsdl2-dev
       - name: Build Emulator
         run: |
@@ -71,11 +71,14 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Dependenncies
+      - name: Install Dependencies
         run: | 
           brew install make sdl2 
       - name: Build Emulator
         run: |
+          ls -l /usr/local/Cellar/
+          ls -lR /usr/local/Cellar/sdl2 || true
+          which libSDL2.a || true
           MAC_STATIC=1 make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ endif
 OUTPUT=x16emu
 
 ifeq ($(MAC_STATIC),1)
-	LDFLAGS=/opt/homebrew/Cellar/sdl2/2.0.20/lib/libSDL2.a -lm -liconv -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
+	LDFLAGS=/usr/local/Cellar/sdl2/2.24.1/lib/libSDL2.a -lm -liconv -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
 endif
 
 ifeq ($(CROSS_COMPILE_WINDOWS),1)

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ifndef WIN_SDL2
 endif
 
 ifeq ($(CROSS_COMPILE_WINDOWS),1)
-	SDL2CONFIG=$(WIN_SDL2)/bin/sdl2-config --prefix=$(WIN_SDL2)
+	SDL2CONFIG?=$(WIN_SDL2)/bin/sdl2-config --prefix=$(WIN_SDL2)
 else
 	SDL2CONFIG=sdl2-config
 endif

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ endif
 OUTPUT=x16emu
 
 ifeq ($(MAC_STATIC),1)
-	LDFLAGS=/usr/local/Cellar/sdl2/2.24.1/lib/libSDL2.a -lm -liconv -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
+	LIBSDL_FILE?=/opt/homebrew/Cellar/sdl2/2.0.20/lib/libSDL2.a
+	LDFLAGS=$(LIBSDL_FILE) -lm -liconv -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
 endif
 
 ifeq ($(CROSS_COMPILE_WINDOWS),1)


### PR DESCRIPTION
Adds a Github Actions workflow file that build the `x16emu` binary on
* Windows using mingw64
* Linux using Ubuntu 20.04 (`ubuntu-latest`)
* Mac on Mac OS 11 Big Sur

Automatically packages in the latest ROM build (`rom.bin`, all `.sym` files) from the x16-rom repository's Github actions in the uploaded artefact.

Thus enables easy download of precompiled binaries for each emulator commit and continuous testing for compilability on every commit.

The ROM repo is currently pointing at my fork, please merge https://github.com/commanderx16/x16-rom/pull/360 first then the repo can be changed to the official `commanderx16` one.

Contains minimum changes to the Makefile with "set variable only if variable wasn't set from the outside" changes so that it picks up the correct `sdl2-config` program on MinGW and a configurable path for the static SDL2 library on Mac. Existing build processes should thus not be broken.

*PS: Please **squash** upon merge, you don't want 20 commits from me)*

Reference run: https://github.com/maxgerhardt/x16-emulator/actions/runs/3397596494