### PR TITLE
Update disasm.c

### DIFF
--- a/src/disasm.c
+++ b/src/disasm.c
@@ -52,7 +52,7 @@ int disasm(uint16_t pc, uint8_t *RAM, char *line, unsigned int max_line, bool de
 			length = 3;
 			snprintf(line, max_line, mnemonic, real_read6502(pc + 1, debugOn, bank) | real_read6502(pc + 2, debugOn, bank) << 8);
 		}
-		if(opcode == 0x00) { 
+		if (opcode == 0x00) { 
 			// BRK instruction is 2 bytes long according to WDC datasheet.
 			// CPU skips the second byte when it executes a BRK.
 			length = 2;

--- a/src/disasm.c
+++ b/src/disasm.c
@@ -52,6 +52,11 @@ int disasm(uint16_t pc, uint8_t *RAM, char *line, unsigned int max_line, bool de
 			length = 3;
 			snprintf(line, max_line, mnemonic, real_read6502(pc + 1, debugOn, bank) | real_read6502(pc + 2, debugOn, bank) << 8);
 		}
+		if(opcode == 0x00) { 
+			// BRK instruction is 2 bytes long according to WDC datasheet.
+			// CPU skips the second byte when it executes a BRK.
+			length = 2;
+		}
 	}
 	return length;
 }


### PR DESCRIPTION
The WDC datasheet states that a BRK instruction is actually two bytes long, with the CPU skipping the second byte by incrementing the program counter past it. The CPU emulation is already doing this, it was just being disassembled incorrectly by the emulator.