### PR TITLE
Fix Linux CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Dependencies
-        run: sudo apt-get install -y build-essential make libsdl2-dev
+        run: sudo apt-get update && sudo apt-get install -y build-essential make libsdl2-dev
       - name: Build Emulator
         run: |
           make V=1 -j3


### PR DESCRIPTION
Does a sudo apt-get update before trying to install anything. Should fix latest CI fail.

```
Fetched 3775 kB in 1s (3853 kB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/s/systemd/libudev-dev_245.4-4ubuntu3.18_amd64.deb  404  Not Found [IP: 52.147.219.192 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```