### PR TITLE
add descriptive reason message when dumping system memory file

### DIFF
--- a/src/glue.h
+++ b/src/glue.h
@@ -62,7 +62,7 @@ extern uint8_t keymap;
 extern bool warp_mode;
 extern bool testbench;
 
-extern void machine_dump();
+extern void machine_dump(const char* reason);
 extern void machine_reset();
 extern void machine_paste(char *text);
 extern void machine_toggle_warp();

--- a/src/main.c
+++ b/src/main.c
@@ -220,8 +220,9 @@ lst_for_address(uint16_t address)
 #endif
 
 void
-machine_dump()
+machine_dump(const char* reason)
 {
+	printf("Dumping system memory. Reason: %s\n", reason);
 	int index = 0;
 	char filename[22];
 	for (;;) {
@@ -1313,7 +1314,7 @@ emulator_loop(void *param)
 
 		if (pc == 0xffff) {
 			if (save_on_exit) {
-				machine_dump();
+				machine_dump("CPU program counter reached $ffff");
 			}
 			break;
 		}

--- a/src/video.c
+++ b/src/video.c
@@ -1107,7 +1107,7 @@ video_update()
 			bool consumed = false;
 			if (cmd_down) {
 				if (event.key.keysym.sym == SDLK_s) {
-					machine_dump();
+					machine_dump("user keyboard request");
 					consumed = true;
 				} else if (event.key.keysym.sym == SDLK_r) {
 					machine_reset();


### PR DESCRIPTION
The emulator writes a memory dump file when pressing CTRL/Command + S, and when the program counter reaches $ffff

This PR adds a descriptive message to the console as well so you can tell why exactly it is writing the dump file. This helps diagnosing what's happening, and for me at least, to tell it apart from an unexpected segfault crash/coredump

```
Dumping system memory. Reason: user keyboard request
Dumped system to dump-7.bin.
Dumping system memory. Reason: CPU program counter reached $ffff
Dumped system to dump-8.bin.
```