### PR TITLE
Make emulator support RAM increments of 8K

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -548,7 +548,7 @@ main(int argc, char **argv)
 			}
 			int kb = atoi(argv[0]);
 			bool found = false;
-			for (int cmp = 8; cmp <= 2048; cmp *= 2) {
+			for (int cmp = 8; cmp <= 2048; cmp += 8) {
 				if (kb == cmp)  {
 					found = true;
 				}

--- a/src/main.c
+++ b/src/main.c
@@ -548,11 +548,7 @@ main(int argc, char **argv)
 			}
 			int kb = atoi(argv[0]);
 			bool found = false;
-			for (int cmp = 8; cmp <= 2048; cmp += 8) {
-				if (kb == cmp)  {
-					found = true;
-				}
-			}
+			if ((kb & 7)==0) found = true;
 			if (!found) {
 				usage();
 			}

--- a/src/main.c
+++ b/src/main.c
@@ -547,9 +547,7 @@ main(int argc, char **argv)
 				usage();
 			}
 			int kb = atoi(argv[0]);
-			bool found = false;
-			if ((kb & 7)==0) found = true;
-			if (!found) {
+			if (!((kb & 7)==0)) {
 				usage();
 			}
 			num_ram_banks = kb /8;


### PR DESCRIPTION
As things were, it was not possible to start the emulator with, for example, 1536KB of memory which would be possible to have in hardware. This change makes it possible to use any multiple of 8K for the amount of RAM