### PR TITLE
Set ISR bits upon VSYNC or LINE IRQs irrespective of what is in IEN

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -950,11 +950,9 @@ update_isr_and_coll(uint16_t y, uint16_t compare)
 			isr = (isr & 0xf) | sprite_line_collisions;
 		}
 		sprite_line_collisions = 0;
-		if (ien & 1) { // VSYNC IRQ
-			isr |= 1;
-		}
+		isr |= 1; // VSYNC IRQ
 	}
-	if ((ien & 2) && (y < SCREEN_HEIGHT) && (y == compare)) { // LINE IRQ
+	if ((y < SCREEN_HEIGHT) && (y == compare)) { // LINE IRQ
 		isr |= 2;
 	}
 }


### PR DESCRIPTION
On real hardware, the ISR bits are set upon their respective events (VSYNC or LINE)  whether or not they are set in IEN.  The emulator had a check for the IEN bit before setting ISR.

The decision whether to assert IRQ does check both IEN and ISR already, so no change was needed there.

Changing the emulator to match real hardware.

Real hardware behavior:
![image](https://user-images.githubusercontent.com/395186/212501506-34e96b01-6878-4651-b051-17195eeea548.png)

Emulator behavior:
![image](https://user-images.githubusercontent.com/395186/212501513-a345b220-80e6-4db2-92c4-6ee3e45c1335.png)

Behavior of emulator after this change:
![image](https://user-images.githubusercontent.com/395186/212501626-f894a98c-060a-42c0-a972-c7c5aeea28c1.png)

