### PR TITLE
Clear sprite buffer when disabling sprites in VERA

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -1409,6 +1409,11 @@ void video_write(uint8_t reg, uint8_t value) {
 				// interlace field bit is read-only
 				reg_composer[0] = (reg_composer[0] & ~0x7f) | (value & 0x7f);
 				video_palette.dirty = true;
+				if ((value & 0x40) == 0) {
+					memset(sprite_line_col, 0, SCREEN_WIDTH);
+					memset(sprite_line_z, 0, SCREEN_WIDTH);
+					memset(sprite_line_mask, 0, SCREEN_WIDTH);
+				}
 			} else {
 				reg_composer[i] = value;
 			}


### PR DESCRIPTION
I noticed that when a raster line interrupt occurs on a line where a sprite is being drawn, and the the sprites are disable during that interrupt, the sprite continues to draw what was in the buffer for that line.

![image](https://user-images.githubusercontent.com/669174/213098306-bba043be-7eaa-4d6d-9657-1d0e21c20b21.png)

To fix this, we can clear the sprite buffers when sprites are disabled by a vera register write.  This is the same clearing that happens per-line when rendering sprites, except we don't replace the pixels.

Here's what it now looks like with this fix in place, which is how it looks on box16 as well as on real VERA hardware:

![image](https://user-images.githubusercontent.com/669174/213099098-89f7f792-fccb-4cee-99f5-b22309fccac8.png)
