### PR TITLE
Implement new audio mixing and emulation timing and update VERA audio emulation

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -3,6 +3,7 @@
 // All rights reserved. License: 2-clause BSD
 
 #include "audio.h"
+#include "glue.h"
 #include "vera_psg.h"
 #include "vera_pcm.h"
 #include "wav_recorder.h"
@@ -14,18 +15,74 @@
 
 #ifdef __EMSCRIPTEN__
 	#define SAMPLES_PER_BUFFER (1024)
+	#define SAMP_POS_FRAC_BITS (22)
 #else
 	#define SAMPLES_PER_BUFFER (256)
+	#define SAMP_POS_FRAC_BITS (24)
 #endif
 
+#define VERA_SAMP_CLKS_PER_CPU_CLK ((25000000ULL << SAMP_POS_FRAC_BITS) / 512 / MHZ / 1000000)
+#define YM_SAMP_CLKS_PER_CPU_CLK ((3579545ULL << SAMP_POS_FRAC_BITS) / 64 / MHZ / 1000000)
+#define SAMPLE_BYTES (2 * sizeof(int16_t))
+#define SAMP_POS_MASK (SAMPLES_PER_BUFFER - 1)
+#define SAMP_POS_MASK_FRAC (((uint32_t)SAMPLES_PER_BUFFER << SAMP_POS_FRAC_BITS) - 1)
+
+// windowed sinc
+static const int16_t filter[512] = {
+	32767,32765,32761,32755,32746,32736,32723,32707,32690,32670,32649,32625,32598,32570,32539,32507,
+	32472,32435,32395,32354,32310,32265,32217,32167,32115,32061,32004,31946,31885,31823,31758,31691,
+	31623,31552,31479,31404,31327,31248,31168,31085,31000,30913,30825,30734,30642,30547,30451,30353,
+	30253,30151,30048,29943,29835,29726,29616,29503,29389,29273,29156,29037,28916,28793,28669,28544,
+	28416,28288,28157,28025,27892,27757,27621,27483,27344,27204,27062,26918,26774,26628,26481,26332,
+	26182,26031,25879,25726,25571,25416,25259,25101,24942,24782,24621,24459,24296,24132,23967,23801,
+	23634,23466,23298,23129,22959,22788,22616,22444,22271,22097,21923,21748,21572,21396,21219,21042,
+	20864,20686,20507,20328,20148,19968,19788,19607,19426,19245,19063,18881,18699,18517,18334,18152,
+	17969,17786,17603,17420,17237,17054,16871,16688,16505,16322,16139,15957,15774,15592,15409,15227,
+	15046,14864,14683,14502,14321,14141,13961,13781,13602,13423,13245,13067,12890,12713,12536,12360,
+	12185,12010,11836,11663,11490,11317,11146,10975,10804,10635,10466,10298,10131, 9964, 9799, 9634,
+	 9470, 9306, 9144, 8983, 8822, 8662, 8504, 8346, 8189, 8033, 7878, 7724, 7571, 7419, 7268, 7118,
+	 6969, 6822, 6675, 6529, 6385, 6241, 6099, 5958, 5818, 5679, 5541, 5405, 5269, 5135, 5002, 4870,
+	 4739, 4610, 4482, 4355, 4229, 4104, 3981, 3859, 3738, 3619, 3500, 3383, 3268, 3153, 3040, 2928,
+	 2817, 2708, 2600, 2493, 2388, 2284, 2181, 2079, 1979, 1880, 1783, 1686, 1591, 1498, 1405, 1314,
+	 1225, 1136, 1049,  963,  879,  795,  714,  633,  554,  476,  399,  323,  249,  176,  105,   34,
+	  -34, -102, -168, -234, -298, -361, -422, -482, -542, -599, -656, -712, -766, -819, -871, -922,
+	 -971,-1020,-1067,-1113,-1158,-1202,-1244,-1286,-1326,-1366,-1404,-1441,-1477,-1512,-1546,-1579,
+	-1611,-1642,-1671,-1700,-1728,-1755,-1781,-1806,-1830,-1852,-1874,-1896,-1916,-1935,-1953,-1971,
+	-1987,-2003,-2018,-2032,-2045,-2058,-2069,-2080,-2090,-2099,-2108,-2116,-2123,-2129,-2134,-2139,
+	-2143,-2147,-2150,-2152,-2153,-2154,-2154,-2154,-2153,-2151,-2149,-2146,-2143,-2139,-2135,-2130,
+	-2124,-2118,-2112,-2105,-2098,-2090,-2082,-2073,-2064,-2054,-2045,-2034,-2024,-2012,-2001,-1989,
+	-1977,-1965,-1952,-1939,-1926,-1912,-1898,-1884,-1870,-1855,-1840,-1825,-1810,-1794,-1778,-1762,
+	-1746,-1730,-1714,-1697,-1680,-1663,-1646,-1629,-1612,-1595,-1577,-1560,-1542,-1525,-1507,-1489, 
+	-1471,-1453,-1435,-1418,-1400,-1382,-1364,-1346,-1328,-1310,-1292,-1274,-1256,-1238,-1220,-1203,
+	-1185,-1167,-1150,-1132,-1115,-1097,-1080,-1063,-1046,-1029,-1012, -995, -978, -962, -945, -929,
+     -912, -896, -880, -864, -849, -833, -817, -802, -787, -772, -757, -742, -727, -713, -699, -684,
+	 -670, -656, -643, -629, -616, -603, -589, -577, -564, -551, -539, -526, -514, -502, -491, -479,
+	 -468, -456, -445, -434, -423, -413, -402, -392, -381, -371, -361, -352, -342, -333, -323, -314,
+	 -305, -296, -288, -279, -270, -262, -254, -246, -238, -230, -222, -215, -207, -200, -193, -186,
+	 -179, -172, -165, -158, -152, -145, -139, -133, -127, -120, -114, -108, -103,  -97,  -91,  -85,
+	  -80,  -74,  -69,  -63,  -58,  -53,  -47,  -42,  -37,  -32,  -27,  -22,  -17,  -12,   -7,   -2
+};
+
 static SDL_AudioDeviceID audio_dev;
-static int               vera_clks = 0;
-static int               cpu_clks  = 0;
-static int16_t **        buffers;
-static int               rdidx    = 0;
-static int               wridx    = 0;
-static int               buf_cnt  = 0;
-static int               num_bufs = 0;
+static int16_t * buffer;
+static uint32_t buffer_size = 0;
+static uint32_t rdidx = 0;
+static uint32_t wridx = 0;
+static uint32_t vera_samp_pos_rd = 0;
+static uint32_t vera_samp_pos_wr = 0;
+static uint32_t vera_samp_pos_hd = 0;
+static uint32_t ym_samp_pos_rd = 0;
+static uint32_t ym_samp_pos_wr = 0;
+static uint32_t ym_samp_pos_hd = 0;
+static uint32_t vera_samps_per_host_samps = 0;
+static uint32_t ym_samps_per_host_samps = 0;
+static uint32_t limiter_amp = 0;
+
+static int16_t psg_buf[2 * SAMPLES_PER_BUFFER];
+static int16_t pcm_buf[2 * SAMPLES_PER_BUFFER];
+static int16_t ym_buf[2 * SAMPLES_PER_BUFFER];
+
+uint32_t host_sample_rate = 0;
 
 static void
 audio_callback(void *userdata, Uint8 *stream, int len)
@@ -34,22 +91,30 @@ audio_callback(void *userdata, Uint8 *stream, int len)
 		return;
 	}
 
-	int expected = 2 * SAMPLES_PER_BUFFER * sizeof(int16_t);
+	int expected = SAMPLES_PER_BUFFER * SAMPLE_BYTES;
 	if (len != expected) {
 		printf("Audio buffer size mismatch! (expected: %d, got: %d)\n", expected, len);
 		return;
 	}
 
-	if (buf_cnt == 0) {
-		memset(stream, 0, len);
-		return;
+	uint32_t spos = 0;
+	if (rdidx > wridx) {
+		uint32_t actual_len = SDL_min(len / SAMPLE_BYTES, (buffer_size - rdidx) / 2);
+		if (actual_len > 0) {
+			memcpy(&stream[spos], &buffer[rdidx], actual_len * SAMPLE_BYTES);
+			spos += actual_len * SAMPLE_BYTES;
+			len -= actual_len * SAMPLE_BYTES;
+			rdidx = (rdidx + actual_len * 2) % buffer_size;
+		}
 	}
-
-	memcpy(stream, buffers[rdidx++], len);
-	if (rdidx == num_bufs) {
-		rdidx = 0;
+	uint32_t actual_len = SDL_min(len / SAMPLE_BYTES, (wridx - rdidx) / 2);
+	if (actual_len > 0) {
+		memcpy(&stream[spos], &buffer[rdidx], actual_len * SAMPLE_BYTES);
+		spos += actual_len * SAMPLE_BYTES;
+		len -= actual_len * SAMPLE_BYTES;
+		rdidx = (rdidx + actual_len * 2) % buffer_size;
 	}
-	buf_cnt--;
+	if (len > 0) memset(&stream[spos], 0, len);
 }
 
 void
@@ -66,19 +131,19 @@ audio_init(const char *dev_name, int num_audio_buffers)
 	}
 
 	// Set number of buffers
-	num_bufs = num_audio_buffers;
+	int num_bufs = num_audio_buffers;
 	if (num_bufs < 3) {
 		num_bufs = 3;
 	}
 	if (num_bufs > 1024) {
 		num_bufs = 1024;
 	}
+	buffer_size = SAMPLES_PER_BUFFER * num_bufs * 2;
 
-	// Allocate audio buffers
-	buffers = malloc(num_bufs * sizeof(*buffers));
-	for (int i = 0; i < num_bufs; i++) {
-		buffers[i] = malloc(2 * SAMPLES_PER_BUFFER * sizeof(buffers[0][0]));
-	}
+	// Allocate audio buffer
+	buffer = malloc(buffer_size * sizeof(int16_t));
+	rdidx = 0;
+	wridx = 0;
 
 	SDL_AudioSpec desired;
 	SDL_AudioSpec obtained;
@@ -91,7 +156,7 @@ audio_init(const char *dev_name, int num_audio_buffers)
 	desired.channels = 2;
 	desired.callback = audio_callback;
 
-	audio_dev = SDL_OpenAudioDevice(dev_name, 0, &desired, &obtained, 0);
+	audio_dev = SDL_OpenAudioDevice(dev_name, 0, &desired, &obtained, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE);
 	if (audio_dev <= 0) {
 		fprintf(stderr, "SDL_OpenAudioDevice failed: %s\n", SDL_GetError());
 		if (dev_name != NULL) {
@@ -99,10 +164,30 @@ audio_init(const char *dev_name, int num_audio_buffers)
 		}
 		exit(-1);
 	}
+	if (obtained.freq <= 0 || (AUDIO_SAMPLERATE / obtained.freq) > SAMPLES_PER_BUFFER) {
+		fprintf(stderr, "Obtained sample rate is too low");
+		audio_close();
+		return;
+	}
 
 	// Init YM2151 emulation. 3.579545 MHz clock
 	YM_Create(3579545);
-	YM_init(obtained.freq, 60);
+	YM_init(3579545/64, 60);
+
+	host_sample_rate = obtained.freq;
+	vera_samps_per_host_samps = ((25000000ULL << SAMP_POS_FRAC_BITS) / 512 / host_sample_rate);
+	ym_samps_per_host_samps = ((3579545ULL << SAMP_POS_FRAC_BITS) / 64 / host_sample_rate);
+	vera_samp_pos_rd = 0;
+	vera_samp_pos_wr = 0;
+	vera_samp_pos_hd = 0;
+	ym_samp_pos_rd = 0;
+	ym_samp_pos_wr = 0;
+	ym_samp_pos_hd = 0;
+	limiter_amp = (1 << 16);
+
+	psg_buf[0] = psg_buf[1] = 0;
+	pcm_buf[0] = pcm_buf[1] = 0;
+	ym_buf[0] = ym_buf[1] = 0;
 
 	// Start playback
 	SDL_PauseAudioDevice(audio_dev, 0);
@@ -119,66 +204,158 @@ audio_close(void)
 	audio_dev = 0;
 
 	// Free audio buffers
-	if (buffers != NULL) {
-		for (int i = 0; i < num_bufs; i++) {
-			if (buffers[i] != NULL) {
-				free(buffers[i]);
-				buffers[i] = NULL;
-			}
-		}
-		free(buffers);
-		buffers = NULL;
+	if (buffer != NULL) {
+		free(buffer);
+		buffer = NULL;
 	}
 }
 
 void
-audio_render(int cpu_clocks)
+audio_step(int cpu_clocks)
 {
+	// Accumulate how many samples each source have to render
 	if (audio_dev == 0) {
 		return;
 	}
 
-	cpu_clks += cpu_clocks;
-	if (cpu_clks > 8) {
-		int c = cpu_clks / 8;
-		cpu_clks -= c * 8;
-		vera_clks += c * 25;
+	while (cpu_clocks > 0) {
+		// Only the source with the higest sample rate (YM2151) is needed for calculation
+		uint32_t max_cpu_clks_ym = ((ym_samp_pos_rd - ym_samp_pos_hd - (1 << SAMP_POS_FRAC_BITS)) & SAMP_POS_MASK_FRAC) / YM_SAMP_CLKS_PER_CPU_CLK;
+		uint32_t max_cpu_clks = SDL_min(cpu_clocks, max_cpu_clks_ym);
+		vera_samp_pos_hd = (vera_samp_pos_hd + max_cpu_clks * VERA_SAMP_CLKS_PER_CPU_CLK) & SAMP_POS_MASK_FRAC;
+		ym_samp_pos_hd = (ym_samp_pos_hd + max_cpu_clks * YM_SAMP_CLKS_PER_CPU_CLK) & SAMP_POS_MASK_FRAC;
+		cpu_clocks -= max_cpu_clks;
+		if (cpu_clocks > 0) audio_render();
+	}
+}
+
+void
+audio_render()
+{
+	// Render all audio sources until read and write positions catch up
+	// This happens when there's a change to sound registers or one of the
+	// sources' sample buffer head position is too far
+	if (audio_dev == 0) {
+		return;
 	}
 
-	while (vera_clks >= 512 * SAMPLES_PER_BUFFER) {
-		vera_clks -= 512 * SAMPLES_PER_BUFFER;
+	uint32_t pos, len;
 
-		int16_t psg_buf[2 * SAMPLES_PER_BUFFER];
-		psg_render(psg_buf, SAMPLES_PER_BUFFER);
+	pos = (vera_samp_pos_wr + 1) & SAMP_POS_MASK;
+	len = ((vera_samp_pos_hd >> SAMP_POS_FRAC_BITS) - vera_samp_pos_wr) & SAMP_POS_MASK;
+	vera_samp_pos_wr = vera_samp_pos_hd >> SAMP_POS_FRAC_BITS;
+	if (pos + len > SAMPLES_PER_BUFFER) {
+		psg_render(&psg_buf[pos * 2], SAMPLES_PER_BUFFER - pos);
+		pcm_render(&pcm_buf[pos * 2], SAMPLES_PER_BUFFER - pos);
+		len -= SAMPLES_PER_BUFFER - pos;
+		pos = 0;
+	}
+	if (len > 0) {
+		psg_render(&psg_buf[pos * 2], len);
+		pcm_render(&pcm_buf[pos * 2], len);
+	}
 
-		int16_t pcm_buf[2 * SAMPLES_PER_BUFFER];
-		pcm_render(pcm_buf, SAMPLES_PER_BUFFER);
+	pos = (ym_samp_pos_wr + 1) & SAMP_POS_MASK;
+	len = ((ym_samp_pos_hd >> SAMP_POS_FRAC_BITS) - ym_samp_pos_wr) & SAMP_POS_MASK;
+	ym_samp_pos_wr = ym_samp_pos_hd >> SAMP_POS_FRAC_BITS;
+	if ((pos + len) > SAMPLES_PER_BUFFER) {
+		YM_stream_update((uint16_t *)&ym_buf[pos * 2], SAMPLES_PER_BUFFER - pos);
+		len -= SAMPLES_PER_BUFFER - pos;
+		pos = 0;
+	}
+	if (len > 0) {
+		YM_stream_update((uint16_t *)&ym_buf[pos * 2], len);
+	}
 
-		int16_t ym_buf[2 * SAMPLES_PER_BUFFER];
-		YM_stream_update((uint16_t *)ym_buf, SAMPLES_PER_BUFFER);
-
-		bool buf_available;
-		SDL_LockAudioDevice(audio_dev);
-		buf_available = buf_cnt < num_bufs;
-		SDL_UnlockAudioDevice(audio_dev);
-
-		if (buf_available) {
-			// Mix PSG, PCM and YM output
-			int16_t *buf = buffers[wridx];
-			for (int i = 0; i < 2 * SAMPLES_PER_BUFFER; i++) {
-				buf[i] = ((int)psg_buf[i] + (int)pcm_buf[i] + (int)ym_buf[i]) / 3;
+	uint32_t wridx_old = wridx;
+	uint32_t len_vera = (vera_samp_pos_hd - vera_samp_pos_rd) & SAMP_POS_MASK_FRAC;
+	uint32_t len_ym = (ym_samp_pos_hd - ym_samp_pos_rd) & SAMP_POS_MASK_FRAC;
+	if (len_vera < (4 << SAMP_POS_FRAC_BITS) || len_ym < (4 << SAMP_POS_FRAC_BITS)) {
+		// not enough samples yet, at least 4 are needed for the filter
+		return;
+	}
+	len_vera = (len_vera - (4 << SAMP_POS_FRAC_BITS)) / vera_samps_per_host_samps;
+	len_ym = (len_ym - (4 << SAMP_POS_FRAC_BITS)) / ym_samps_per_host_samps;
+	len = SDL_min(len_vera, len_ym);
+	SDL_LockAudioDevice(audio_dev);
+	for (int i = 0; i < len; i++) {
+		int32_t samp[8];
+		int32_t filter_idx = 0;
+		int32_t vera_out_l = 0;
+		int32_t vera_out_r = 0;
+		int32_t ym_out_l = 0;
+		int32_t ym_out_r = 0;
+		// Don't resample VERA outputs if the host sample rate is as desired
+		if (host_sample_rate == AUDIO_SAMPLERATE) {
+			pos = (vera_samp_pos_rd >> SAMP_POS_FRAC_BITS) * 2;
+			vera_out_l = ((int32_t)psg_buf[pos] + (int32_t)pcm_buf[pos]) / 2 * 32768;
+			vera_out_r = ((int32_t)psg_buf[pos + 1] + (int32_t)pcm_buf[pos + 1]) / 2 * 32768;
+		} else {
+			filter_idx = (vera_samp_pos_rd >> (SAMP_POS_FRAC_BITS - 8)) & 0xff;
+			for (int j = 0; j < 8; j += 2) {
+				pos = (vera_samp_pos_rd >> SAMP_POS_FRAC_BITS) * 2;
+				samp[j] = ((int32_t)psg_buf[pos] + (int32_t)pcm_buf[pos]) / 2;
+				samp[j + 1] = ((int32_t)psg_buf[pos + 1] + (int32_t)pcm_buf[pos + 1]) / 2;
+				pos = (pos + 2) & (SAMP_POS_MASK * 2);
 			}
-
-			wav_recorder_process(buf, SAMPLES_PER_BUFFER);
-
-			SDL_LockAudioDevice(audio_dev);
-			wridx++;
-			if (wridx == num_bufs) {
-				wridx = 0;
-			}
-			buf_cnt++;
-			SDL_UnlockAudioDevice(audio_dev);
+			vera_out_l += samp[0] * filter[256 + filter_idx];
+			vera_out_r += samp[1] * filter[256 + filter_idx];
+			vera_out_l += samp[2] * filter[  0 + filter_idx];
+			vera_out_r += samp[3] * filter[  0 + filter_idx];
+			vera_out_l += samp[4] * filter[255 - filter_idx];
+			vera_out_r += samp[5] * filter[255 - filter_idx];
+			vera_out_l += samp[6] * filter[511 - filter_idx];
+			vera_out_r += samp[7] * filter[511 - filter_idx];
 		}
+		filter_idx = (ym_samp_pos_rd >> (SAMP_POS_FRAC_BITS - 8)) & 0xff;
+		for (int j = 0; j < 8; j += 2) {
+			pos = (ym_samp_pos_rd >> SAMP_POS_FRAC_BITS) * 2;
+			samp[j] = ym_buf[pos];
+			samp[j + 1] = ym_buf[pos + 1];
+			pos = (pos + 2) & (SAMP_POS_MASK * 2);
+		}
+		ym_out_l += samp[0] * filter[256 + filter_idx];
+		ym_out_r += samp[1] * filter[256 + filter_idx];
+		ym_out_l += samp[2] * filter[  0 + filter_idx];
+		ym_out_r += samp[3] * filter[  0 + filter_idx];
+		ym_out_l += samp[4] * filter[255 - filter_idx];
+		ym_out_r += samp[5] * filter[255 - filter_idx];
+		ym_out_l += samp[6] * filter[511 - filter_idx];
+		ym_out_r += samp[7] * filter[511 - filter_idx];
+		// Mixing is according to Proto3 hardware recording
+		// Loudest single PSG channel is 1/8 times the max output
+		// mix = (psg + pcm) * 2 + ym / 2
+		int32_t mix_l = (vera_out_l >> 13) + (ym_out_l >> 16);
+		int32_t mix_r = (vera_out_r >> 13) + (ym_out_r >> 16);
+		uint32_t amp = SDL_max(SDL_abs(mix_l), SDL_abs(mix_r));
+		if (amp > 32767) {
+			uint32_t limiter_amp_new = (32767 << 16) / amp;
+			limiter_amp = SDL_min(limiter_amp_new, limiter_amp);
+		}
+		buffer[wridx++] = (int16_t)((mix_l * limiter_amp) >> 16);
+		buffer[wridx++] = (int16_t)((mix_r * limiter_amp) >> 16);
+		if (limiter_amp < (1 << 16)) limiter_amp++;
+		vera_samp_pos_rd = (vera_samp_pos_rd + vera_samps_per_host_samps) & SAMP_POS_MASK_FRAC;
+		ym_samp_pos_rd = (ym_samp_pos_rd + ym_samps_per_host_samps) & SAMP_POS_MASK_FRAC;
+		if (wridx == buffer_size) {
+			wav_recorder_process(&buffer[wridx_old], (buffer_size - wridx_old) / 2);
+			wridx = 0;
+			wridx_old = 0;
+		}
+	}
+	if ((wridx - wridx_old) > 0) {
+		wav_recorder_process(&buffer[wridx_old], (wridx - wridx_old) / 2);
+	}
+	SDL_UnlockAudioDevice(audio_dev);
+
+	// catch up all buffers if they are too far behind
+	uint32_t skip = len_vera - len;
+	if (skip > 1) {
+		vera_samp_pos_rd = (vera_samp_pos_rd + vera_samps_per_host_samps) & SAMP_POS_MASK_FRAC;
+	}
+	skip = len_ym - len;
+	if (skip > 1) {
+		ym_samp_pos_rd = (ym_samp_pos_rd + ym_samps_per_host_samps) & SAMP_POS_MASK_FRAC;
 	}
 }
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -78,8 +78,8 @@ static uint32_t vera_samps_per_host_samps = 0;
 static uint32_t ym_samps_per_host_samps = 0;
 static uint32_t limiter_amp = 0;
 
-static int16_t psg_buf[2 * SAMPLES_PER_BUFFER];
-static int16_t pcm_buf[2 * SAMPLES_PER_BUFFER];
+static int32_t psg_buf[2 * SAMPLES_PER_BUFFER];
+static int32_t pcm_buf[2 * SAMPLES_PER_BUFFER];
 static int16_t ym_buf[2 * SAMPLES_PER_BUFFER];
 
 uint32_t host_sample_rate = 0;
@@ -288,14 +288,14 @@ audio_render()
 		// Don't resample VERA outputs if the host sample rate is as desired
 		if (host_sample_rate == AUDIO_SAMPLERATE) {
 			pos = (vera_samp_pos_rd >> SAMP_POS_FRAC_BITS) * 2;
-			vera_out_l = ((int32_t)psg_buf[pos] + (int32_t)pcm_buf[pos]) / 2 * 32768;
-			vera_out_r = ((int32_t)psg_buf[pos + 1] + (int32_t)pcm_buf[pos + 1]) / 2 * 32768;
+			vera_out_l = ((psg_buf[pos] + pcm_buf[pos]) >> 8) * 32768;
+			vera_out_r = ((psg_buf[pos + 1] + pcm_buf[pos + 1]) >> 8) * 32768;
 		} else {
 			filter_idx = (vera_samp_pos_rd >> (SAMP_POS_FRAC_BITS - 8)) & 0xff;
 			for (int j = 0; j < 8; j += 2) {
 				pos = (vera_samp_pos_rd >> SAMP_POS_FRAC_BITS) * 2;
-				samp[j] = ((int32_t)psg_buf[pos] + (int32_t)pcm_buf[pos]) / 2;
-				samp[j + 1] = ((int32_t)psg_buf[pos + 1] + (int32_t)pcm_buf[pos + 1]) / 2;
+				samp[j] = (psg_buf[pos] + pcm_buf[pos]) >> 8;
+				samp[j + 1] = (psg_buf[pos + 1] + pcm_buf[pos + 1]) >> 8;
 				pos = (pos + 2) & (SAMP_POS_MASK * 2);
 			}
 			vera_out_l += samp[0] * filter[256 + filter_idx];

--- a/src/audio.h
+++ b/src/audio.h
@@ -10,6 +10,7 @@
 
 void audio_init(const char *dev_name, int num_audio_buffers);
 void audio_close(void);
-void audio_render(int cpu_clocks);
+void audio_step(int cpu_clocks);
+void audio_render();
 
 void audio_usage(void);

--- a/src/glue.h
+++ b/src/glue.h
@@ -61,6 +61,7 @@ extern char *gif_path;
 extern uint8_t keymap;
 extern bool warp_mode;
 extern bool testbench;
+extern uint32_t host_sample_rate;
 
 extern void machine_dump(const char* reason);
 extern void machine_reset();

--- a/src/main.c
+++ b/src/main.c
@@ -440,7 +440,7 @@ usage()
 	printf("\tPOKE $9FB5,2 to start recording.\n");
 	printf("\tPOKE $9FB5,1 to capture a single frame.\n");
 	printf("\tPOKE $9FB5,0 to pause.\n");
-	printf("-wav <file.gif>[{,wait|,auto}]\n");
+	printf("-wav <file.wav>[{,wait|,auto}]\n");
 	printf("\tRecord a wav for the audio output.\n");
 	printf("\tUse ,wait to start paused, or ,auto to start paused and automatically begin recording on the first non-zero audio signal.\n");
 	printf("\tPOKE $9FB6,2 to automatically begin recording on the first non-zero audio signal.\n");
@@ -1271,7 +1271,7 @@ emulator_loop(void *param)
 		rtc_step(clocks);
 
 		if (!headless) {
-			audio_render(clocks);
+			audio_step(clocks);
 		}
 
 		instruction_counter++;

--- a/src/memory.c
+++ b/src/memory.c
@@ -14,6 +14,7 @@
 #include "ym2151.h"
 #include "cpu/fake6502.h"
 #include "wav_recorder.h"
+#include "audio.h"
 
 uint8_t ram_bank;
 uint8_t rom_bank;
@@ -177,6 +178,7 @@ write6502(uint16_t address, uint8_t value)
 			if (address == 0x9f40) {        // YM address
 				addr_ym = value;
 			} else if (address == 0x9f41) { // YM data
+				audio_render();
 				YM_write_reg(addr_ym, value);
 			}
 			// TODO:

--- a/src/vera_pcm.c
+++ b/src/vera_pcm.c
@@ -105,7 +105,7 @@ pcm_is_fifo_almost_empty(void)
 }
 
 void
-pcm_render(int16_t *buf, unsigned num_samples)
+pcm_render(int32_t *buf, unsigned num_samples)
 {
 	while (num_samples--) {
 		uint8_t old_phase = phase;
@@ -137,8 +137,7 @@ pcm_render(int16_t *buf, unsigned num_samples)
 				}
 			}
 		}
-
-		*(buf++) = ((int)cur_l * (int)volume_lut[ctrl & 0xF]) >> 6;
-		*(buf++) = ((int)cur_r * (int)volume_lut[ctrl & 0xF]) >> 6;
+		*(buf++) = (int32_t)cur_l * volume_lut[ctrl & 0xF] << 1;
+		*(buf++) = (int32_t)cur_r * volume_lut[ctrl & 0xF] << 1;
 	}
 }

--- a/src/vera_pcm.h
+++ b/src/vera_pcm.h
@@ -13,5 +13,5 @@ uint8_t pcm_read_ctrl(void);
 void    pcm_write_rate(uint8_t val);
 uint8_t pcm_read_rate(void);
 void    pcm_write_fifo(uint8_t val);
-void    pcm_render(int16_t *buf, unsigned num_samples);
+void    pcm_render(int32_t *buf, unsigned num_samples);
 bool    pcm_is_fifo_almost_empty(void);

--- a/src/vera_psg.c
+++ b/src/vera_psg.c
@@ -5,15 +5,7 @@
 #include "vera_psg.h"
 
 #include <stdbool.h>
-#include <stdlib.h>
 #include <string.h>
-
-// enable anti-aliasing for saw and pulse
-#define AA_PULSE
-#define AA_SAWTOOTH
-
-// aliasing in triangle is already barely audible, so don't bother
-// #define AA_TRIANGLE
 
 enum waveform {
 	WF_PULSE = 0,
@@ -24,58 +16,34 @@ enum waveform {
 
 struct channel {
 	uint16_t freq;
-	uint8_t  volume;
+	uint16_t volume;
 	bool     left, right;
 	uint8_t  pw;
 	uint8_t  waveform;
 
-	uint8_t  noiseval;
-	unsigned phase;
-
-	#if defined(AA_PULSE) || defined(AA_SAWTOOTH) || defined(AA_TRIANGLE)
-	unsigned inv_freq;
-	#endif
-
-	#ifdef AA_TRIANGLE
-	uint16_t freq_3;
-	#endif
+	uint16_t noiseval;
+	uint32_t phase;
 };
 
 static struct channel channels[16];
 
-static uint8_t volume_lut[64] = {0, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 6, 6, 7, 7, 7, 8, 8, 9, 9, 10, 11, 11, 12, 13, 14, 14, 15, 16, 17, 18, 19, 21, 22, 23, 25, 26, 28, 29, 31, 33, 35, 37, 39, 42, 44, 47, 50, 52, 56, 59, 63};
+static uint16_t volume_lut[64] = {
+	  0,                                          14,  15,  16,
+	 16,  17,  19,  20,  21,  22,  23,  25,  26,  28,  30,  32,
+	 33,  35,  38,  40,  42,  45,  47,  50,  53,  57,  60,  64,
+	 67,  71,  76,  80,  85,  90,  95, 101, 107, 114, 120, 128,
+	135, 143, 152, 161, 170, 181, 191, 203, 215, 228, 241, 256,
+	271, 287, 304, 322, 341, 362, 383, 406, 430, 456, 483, 512
+};
+
+static uint16_t noise_out, noise_state;
 
 void
 psg_reset(void)
 {
 	memset(channels, 0, sizeof(channels));
-}
-
-static unsigned
-calc_inv_freq(const unsigned freq)
-{
-	static const unsigned n = 0x7FFFFFFF;
-	return freq ? n / freq : n;
-}
-
-__attribute__((unused)) static unsigned
-calc_freq_3(const unsigned freq)
-{
-	return (freq << 1) / 3;
-}
-
-static void
-set_freq(struct channel *ch, const unsigned freq)
-{
-	ch->freq = freq;
-
-	#if defined(AA_PULSE) || defined(AA_SAWTOOTH) || defined(AA_TRIANGLE)
-	ch->inv_freq = calc_inv_freq(freq);
-	#endif
-
-	#ifdef AA_TRIANGLE
-	ch->freq_3 = calc_freq_3(freq);
-	#endif
+	noise_out = 0;
+	noise_state = 1;
 }
 
 void
@@ -87,8 +55,8 @@ psg_writereg(uint8_t reg, uint8_t val)
 	int idx = reg & 3;
 
 	switch (idx) {
-		case 0: set_freq(&channels[ch], (channels[ch].freq & 0xFF00) | val); break;
-		case 1: set_freq(&channels[ch], (channels[ch].freq & 0x00FF) | (val << 8)); break;
+		case 0: channels[ch].freq = (channels[ch].freq & 0xFF00) | val; break;
+		case 1: channels[ch].freq = (channels[ch].freq & 0x00FF) | (val << 8); break;
 		case 2: {
 			channels[ch].right  = (val & 0x80) != 0;
 			channels[ch].left   = (val & 0x40) != 0;
@@ -103,123 +71,40 @@ psg_writereg(uint8_t reg, uint8_t val)
 	}
 }
 
-static unsigned
-poly_x(const unsigned phase, const unsigned inv_freq)
-{
-	return ~((phase * inv_freq) >> 16) & 0x7FFF;
-}
-
-static int
-poly_blep(unsigned phase, const unsigned inv_freq, const unsigned freq)
-{
-	const bool dir = phase >= freq;
-	if (dir && (phase ^= 0x1FFFF) >= freq) {
-		return 0;
-	}
-
-	const unsigned x = poly_x(phase, inv_freq);
-	const int y1 = (x * x) >> 25, y2 = -y1;
-
-	return dir ? y1 : y2;
-}
-
-static int
-pulse_blep(unsigned phase, const unsigned inv_freq, const unsigned freq, const unsigned pw)
-{
-	int y = 0;
-
-	for (int i = 0; i < 2; ++ i) {
-		const int x1 = poly_blep(phase, inv_freq, freq), x2 = -x1;
-		y += !i ? x1 : x2;
-
-		if (!i) {
-			phase = (phase + 0x20000 - ((pw + 1) << 10)) & 0x1FFFF;
-		} else {
-			break;
-		}
-	}
-
-	return y;
-}
-
-static int
-poly_blamp(unsigned phase, const unsigned inv_freq, const unsigned freq)
-{
-	if (phase >= freq && (phase ^= 0x1FFFF) >= freq) {
-		return 0;
-	}
-
-	const unsigned x = poly_x(phase, inv_freq);
-	const int y = ((x * x) >> 14) * x;
-
-	return y;
-}
-
-__attribute__((unused)) static int
-triangle_blamp(unsigned phase, const unsigned inv_freq, const unsigned freq, const int freq_3)
-{
-	int y = 0;
-
-	for (int i = 0; i < 2; ++i) {
-		const int x1 = poly_blamp(phase, inv_freq, freq), x2 = -x1;
-		y += !i ? x1 : x2;
-
-		if (!i) {
-			phase = (phase + 0x10000) & 0x1FFFF;
-		} else {
-			break;
-		}
-	}
-
-	return ((y >> 16) * freq_3) >> 26;
-}
-
 static void
-render(int16_t *left, int16_t *right)
+render(int32_t *left, int32_t *right)
 {
-	int l = 0;
-	int r = 0;
+	int32_t l = 0;
+	int32_t r = 0;
 
 	for (int i = 0; i < 16; i++) {
+		// In FPGA implementation, noise values are generated every system clock and
+		// the channel update is run sequentially. So, even if both two channels are
+		// fetching a noise value in the same sample, they should have different values
+		noise_out = ((noise_out << 1) | (noise_state & 1)) & 0x3FF;
+		noise_state = (noise_state << 1) | (((noise_state >> 1) ^ (noise_state >> 2) ^ (noise_state >> 4) ^ (noise_state >> 15)) & 1);
+
 		struct channel *ch = &channels[i];
 
-		unsigned new_phase = (ch->phase + ch->freq) & 0x1FFFF;
+		uint32_t new_phase = (ch->left || ch->right) ? ((ch->phase + ch->freq) & 0x1FFFF) : 0;
 		if ((ch->phase & 0x10000) != (new_phase & 0x10000)) {
-			ch->noiseval = rand() & 63;
+			ch->noiseval = noise_out;
 		}
 		ch->phase = new_phase;
 
-		int v = 0;
+		uint32_t v = 0;
 		switch (ch->waveform) {
-			case WF_PULSE: {
-				v = (ch->phase >> 10) > ch->pw ? 0 : 63;
-
-				#ifdef AA_PULSE
-				v += pulse_blep(ch->phase, ch->inv_freq, ch->freq, ch->pw);
-				#endif
-				break;
-			}
-			case WF_SAWTOOTH: {
-				v = ch->phase >> 11;
-
-				#ifdef AA_SAWTOOTH
-				v -= poly_blep(ch->phase, ch->inv_freq, ch->freq);
-				#endif
-				break;
-			}
-			case WF_TRIANGLE: {
-				v = (ch->phase & 0x10000) ? (~(ch->phase >> 10) & 0x3F) : ((ch->phase >> 10) & 0x3F);
-
-				#ifdef AA_TRIANGLE
-				v += triangle_blamp(ch->phase, ch->inv_freq, ch->freq, ch->freq_3);
-				#endif
-				break;
-			}
+			case WF_PULSE: v = ((ch->phase >> 10) > ch->pw) ? 0 : 0x3FF; break;
+			case WF_SAWTOOTH: v = ch->phase >> 7; break;
+			case WF_TRIANGLE: v = (ch->phase & 0x10000) ? (~(ch->phase >> 6) & 0x3FF) : ((ch->phase >> 6) & 0x3FF); break;
 			case WF_NOISE: v = ch->noiseval; break;
 		}
-		v -= 32;
+		int32_t sv = (v ^ 0x200);
+		if (sv & 0x200) {
+			sv |= 0xFFFFFC00;
+		}
 
-		int val = v * (int)ch->volume;
+		int32_t val = sv * ch->volume;
 
 		if (ch->left) {
 			l += val;
@@ -234,7 +119,7 @@ render(int16_t *left, int16_t *right)
 }
 
 void
-psg_render(int16_t *buf, unsigned num_samples)
+psg_render(int32_t *buf, unsigned num_samples)
 {
 	while (num_samples--) {
 		render(&buf[0], &buf[1]);

--- a/src/vera_psg.h
+++ b/src/vera_psg.h
@@ -8,4 +8,4 @@
 
 void psg_reset(void);
 void psg_writereg(uint8_t reg, uint8_t val);
-void psg_render(int16_t *buf, unsigned num_samples);
+void psg_render(int32_t *buf, unsigned num_samples);

--- a/src/video.c
+++ b/src/video.c
@@ -16,6 +16,7 @@
 #include "icon.h"
 #include "sdcard.h"
 #include "i2c.h"
+#include "audio.h"
 
 #include <limits.h>
 #include <stdint.h>
@@ -1276,6 +1277,7 @@ video_space_write(uint32_t address, uint8_t value)
 	video_ram[address & 0x1FFFF] = value;
 
 	if (address >= ADDR_PSG_START && address < ADDR_PSG_END) {
+		audio_render();
 		psg_writereg(address & 0x3f, value);
 	} else if (address >= ADDR_PALETTE_START && address < ADDR_PALETTE_END) {
 		palette[address & 0x1ff] = value;
@@ -1437,9 +1439,9 @@ void video_write(uint8_t reg, uint8_t value) {
 			refresh_layer_properties(1);
 			break;
 
-		case 0x1B: pcm_write_ctrl(value); break;
-		case 0x1C: pcm_write_rate(value); break;
-		case 0x1D: pcm_write_fifo(value); break;
+		case 0x1B: audio_render(); pcm_write_ctrl(value); break;
+		case 0x1C: audio_render(); pcm_write_rate(value); break;
+		case 0x1D: audio_render(); pcm_write_fifo(value); break;
 
 		case 0x1E:
 		case 0x1F:

--- a/src/wav_recorder.c
+++ b/src/wav_recorder.c
@@ -6,6 +6,7 @@
 
 #include "SDL.h"
 #include "audio.h"
+#include "glue.h"
 #include <string.h>
 #include <stdlib.h>
 
@@ -153,7 +154,7 @@ wav_recorder_process(const int16_t *samples, const int num_samples)
 		for (i = 0; i < num_samples; ++i) {
 			if (samples[i] != 0) {
 				Wav_record_state = RECORD_WAV_RECORDING;
-				wav_begin(Wav_path, AUDIO_SAMPLERATE);
+				wav_begin(Wav_path, host_sample_rate);
 				break;
 			}
 		}
@@ -174,7 +175,7 @@ wav_recorder_set(wav_recorder_command_t command)
 				break;
 			case RECORD_WAV_RECORD:
 				Wav_record_state = RECORD_WAV_RECORDING;
-				wav_begin(Wav_path, AUDIO_SAMPLERATE);
+				wav_begin(Wav_path, host_sample_rate);
 				break;
 			case RECORD_WAV_AUTOSTART:
 				Wav_record_state = RECORD_WAV_AUTOSTARTING;
@@ -216,7 +217,7 @@ wav_recorder_set_path(const char *path)
 			Wav_record_state               = RECORD_WAV_AUTOSTARTING;
 		} else {
 			Wav_record_state = RECORD_WAV_RECORDING;
-			wav_begin(Wav_path, AUDIO_SAMPLERATE);
+			wav_begin(Wav_path, host_sample_rate);
 		}
 	} else {
 		Wav_record_state = RECORD_WAV_DISABLED;


### PR DESCRIPTION
In preparation of a new YM2151 core which lacks resampling, the audio routine is very much rewritten.
- The mixer can mix VERA and YM2151 sources sampled in each of its native sample rate
- The mixer can output in any sample rate, 48828Hz sample rate request is now not enforced to SDL
- Implement a 4-tap filter to resample with minimal aliasing
- Mixing between VERA and YM2151 is changed to reflect Proto3 hardware: VERA is now 6 times louder and YM2151 is 1.5 times louder. A simple limiter is implemented to remove potential clippings from this change.

Timing now uses elapsed CPU clocks as a base instead of elapsed frames, as VERA has different frame rates in each output mode which is not exactly 60Hz and reliable. This reduces (almost) all crackling problems introduced after the video timing rewrite.

VERA PSG and PCM behavior is updated to upstream hardware. Changes including full 24-bit mixing, more PSG resolution (less triangle aliasing and finer volume steps), same LFSR noise algorithm and phase resetting on disabled output. However, this necessitates a removal of anti-aliasing code introduced in #355 as this is not a hardware behavior to begin with.

This still needs lots of testing. I'm still not sure if tiny clicks are completely removed and web builds still work.