### PR TITLE
CI/CD: Add Win32 build, remove tar step on Linux/Darwin builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,44 @@ jobs:
         with:
           name: X16-Emu Windows 64-bit
           path: emu_binaries/*
+  build-win32:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: make mingw-w64-i686-toolchain mingw-w64-i686-libelf mingw-w64-i686-SDL2
+          path-type: inherit
+      - name: Add /mingw32/bin to path
+        run: echo "/mingw32/bin" >> $GITHUB_PATH
+      - name: Build Emulator
+        run: |
+          WIN_SDL2=/mingw32 TARGET_CPU=x86 CROSS_COMPILE_WINDOWS=1 make V=1 -j2
+          mkdir emu_binaries
+          cp $(which SDL2.dll) emu_binaries/.
+          cp sdcard.img.zip emu_binaries/.
+          cp x16emu.exe emu_binaries/.
+          file emu_binaries/*
+      - name: Download latest ROM
+        id: download
+        run: |
+          gh run download -R commanderx16/x16-rom -n "ROM Image" --dir latest_rom
+        shell: cmd
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Copy ROM
+        run: |
+          cp latest_rom/rom.bin emu_binaries/.
+          cp latest_rom/*.sym emu_binaries/.
+      - uses: actions/upload-artifact@v3
+        with:
+          name: X16-Emu Windows 32-bit
+          path: emu_binaries/*
   build-lin64:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,12 +60,10 @@ jobs:
         run: |
           cp latest_rom/rom.bin emu_binaries/.
           cp latest_rom/*.sym emu_binaries/.
-      - name: Tar files
-        run: tar -cvf x16emu.tar.gz -C emu_binaries .
       - uses: actions/upload-artifact@v3
         with:
           name: X16-Emu Linux 64-bit
-          path: x16emu.tar.gz
+          path: emu_binaries/*
   build-darwin-x64:
     # this is currently macos-11, Big Sur
     runs-on: macos-latest
@@ -91,9 +89,7 @@ jobs:
         run: |
           cp latest_rom/rom.bin emu_binaries/.
           cp latest_rom/*.sym emu_binaries/.
-      - name: Tar files
-        run: tar -cvf x16emu.tar.gz -C emu_binaries .
       - uses: actions/upload-artifact@v3
         with:
           name: X16-Emu Mac Intel 64-bit
-          path: x16emu.tar.gz
+          path: emu_binaries/*

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,11 @@ ifeq ($(CROSS_COMPILE_WINDOWS),1)
 	LDFLAGS+=-L$(MINGW32)/lib
 	# this enables printf() to show, but also forces a console window
 	LDFLAGS+=-Wl,--subsystem,console
+ifeq ($(TARGET_CPU),x86)
+	CC=i686-w64-mingw32-gcc
+else
 	CC=x86_64-w64-mingw32-gcc
+endif
 endif
 
 ifdef EMSCRIPTEN


### PR DESCRIPTION
There was an unnecessary tar step for Linux and Mac builds in the GitHub workflows. Besides creating what was actually a .tar file while calling it .tar.gz, it was still wrapped in a .zip file by the GitHub CD workflow.

A plain zip file is totally fine even for the Linux and Mac builds.