### PR TITLE
Add both of the recent flavors of MacOS to CI/CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,9 +102,9 @@ jobs:
         with:
           name: X16-Emu Linux 64-bit
           path: emu_binaries/*
-  build-darwin-x64:
+  build-darwin-11-x64:
     # this is currently macos-11, Big Sur
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v3
       - name: Install Dependencies
@@ -129,5 +129,34 @@ jobs:
           cp latest_rom/*.sym emu_binaries/.
       - uses: actions/upload-artifact@v3
         with:
-          name: X16-Emu Mac Intel 64-bit
+          name: X16-Emu MacOS 11 Big Sur Intel 64-bit
+          path: emu_binaries/*
+  build-darwin-12-x64:
+    # this is currently macos-12, Monterey
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Dependencies
+        run: | 
+          brew install make sdl2 
+      - name: Build Emulator
+        run: |
+          MAC_STATIC=1 LIBSDL_FILE=/usr/local/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
+          mkdir emu_binaries
+          cp sdcard.img.zip emu_binaries/.
+          cp x16emu emu_binaries/.
+          file emu_binaries/*
+      - name: Download latest ROM
+        id: download
+        run: |
+          gh run download -R commanderx16/x16-rom -n "ROM Image" --dir latest_rom
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Copy ROM
+        run: |
+          cp latest_rom/rom.bin emu_binaries/.
+          cp latest_rom/*.sym emu_binaries/.
+      - uses: actions/upload-artifact@v3
+        with:
+          name: X16-Emu MacOS 12 Monterey Intel 64-bit
           path: emu_binaries/*


### PR DESCRIPTION
Change workflow to build explicit MacOS 11 and 12 builds rather than always using macos-latest