### PR TITLE
SPRCOL bits should be set in ISR irrespective of IEN

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -943,12 +943,10 @@ static void
 update_isr_and_coll(uint16_t y, uint16_t compare)
 {
 	if (y == SCREEN_HEIGHT) {
-		if (ien & 4) {
-			if (sprite_line_collisions != 0) {
-				isr |= 4;
-			}
-			isr = (isr & 0xf) | sprite_line_collisions;
+		if (sprite_line_collisions != 0) {
+			isr |= 4;
 		}
+		isr = (isr & 0xf) | sprite_line_collisions;
 		sprite_line_collisions = 0;
 		isr |= 1; // VSYNC IRQ
 	}


### PR DESCRIPTION
AFLOW, SPRCOL, LINE, and VSYNC bits in ISR should be set regardless of what happens to be in IEN.  In https://github.com/commanderx16/x16-emulator/pull/462 we fixed this for LINE and VSYNC, but I missed SPRCOL, which is fixed in this PR.

Hardware:
![image](https://user-images.githubusercontent.com/395186/214965367-f81e2838-ae14-4458-b394-79266c9acbd4.png)

Emulator before fix:
![image](https://user-images.githubusercontent.com/395186/214965406-418de59d-66c9-4e3e-8682-f760050c3912.png)

Emulator after fix:
![image](https://user-images.githubusercontent.com/395186/214965430-7eedf8d1-3194-4dcc-9bbe-2d6c9cdac65f.png)
