### PR TITLE
Add WebAssembly build to GitHub Actions (CI/CD)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,3 +160,29 @@ jobs:
         with:
           name: X16-Emu MacOS 12 Monterey Intel 64-bit
           path: emu_binaries/*
+  build-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential make libsdl2-dev
+      - uses: mymindstorm/setup-emsdk@v12
+      - name: Download latest ROM
+        id: download
+        run: |
+          gh run download -R commanderx16/x16-rom -n "ROM Image" --dir latest_rom
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build Emulator
+        run: |
+          cp latest_rom/rom.bin .
+          make V=1 -j3 wasm
+          mkdir emu_binaries
+          cp x16emu.data x16emu.html x16emu.js x16emu.wasm emu_binaries/
+          mkdir emu_binaries/webassembly
+          cp webassembly/styles.css webassembly/main.js emu_binaries/webassembly/
+          file emu_binaries/*
+      - uses: actions/upload-artifact@v3
+        with:
+          name: X16-Emu Webassembly
+          path: emu_binaries/*

--- a/src/ieee.c
+++ b/src/ieee.c
@@ -9,6 +9,10 @@
 // * serial.c: L1: Serial Bus emulation (low level)
 // * main.c: IEEE KERNAL call hooks (high level)
 
+#ifndef __APPLE__
+#define _XOPEN_SOURCE   600
+#define _POSIX_C_SOURCE 1
+#endif
 #include <string.h>
 #include <stdio.h>
 #include <stdbool.h>


### PR DESCRIPTION
Confirmed that this produces a working build that works in a browser.