### PR TITLE
HostFS: Fix behavior of realpath() on Windows.  Clear carry flag on return from hostfs ACPTR

### DIFF
--- a/src/ieee.c
+++ b/src/ieee.c
@@ -84,7 +84,8 @@ realpath(const char *path, char *resolved_path) {
 	char *ret = _fullpath(resolved_path, path, PATH_MAX);
 
 	if (ret && _access(ret,0) && errno == ENOENT) {
-		free(ret);
+		if (resolved_path == NULL)
+			free(ret);
 		return NULL;
 	}
 

--- a/src/ieee.c
+++ b/src/ieee.c
@@ -303,6 +303,15 @@ resolve_path(const char *name, bool must_exist)
 	ret = realpath(tmp, NULL);
 	free(tmp);
 
+#ifdef __MINGW32__
+	if (ret && _access(ret,0)) {
+		if (errno == ENOENT) {
+			free(ret);
+			ret = NULL;
+		}
+	}
+#endif
+
 	if (ret == NULL) {
 		if (must_exist) {
 			// path wasn't found or had another error in construction

--- a/src/main.c
+++ b/src/main.c
@@ -1127,7 +1127,7 @@ handle_ieee_intercept()
 			break;
 		case 0xFFA5:
 			s=ACPTR(&a);
-			status = (status & ~2) | (!a << 1);
+			status = (status & ~3) | (!a << 1); // unconditional CLC, and set zero flag based on byte read
 			break;
 		case 0xFFA8:
 			s=CIOUT(a);


### PR DESCRIPTION
This PR addresses two distinct problems.

_fullpath() on windows returns a valid path even if the final part does not exist.  This differs from the behavior of realpath(), so I changed the macro into a function call that implements realpath() behavior on Windows.

Emulated ACPTR was leaving the state of the carry flag alone, which confuses BASIC if it's not cleared..  This is the counterpart of the behavior for write that was described in https://github.com/commanderx16/x16-emulator/issues/416 which I had fixed in the main hostfs PR, but for reading instead of writing.  The real ROM code clears carry unconditionally on return from ACPTR, so the hostfs code must as well.